### PR TITLE
IBM Spectrum Scale Ansible Callhome Roles pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Ansible project with multiple roles(precheck, node, cluster and postcheck) for i
 - [x] Configure performance monitoring and collectors
 - [ ] Configure HA federated mode collectors
 
+#### GPFS Callhome Cluster build supported features
+- [x] Install GPFS callhome packages on all cluster nodes
+- [x] Configure callhome
+
 IBM Spectrum Scale supported versions
 -------------------------------------
 
@@ -248,6 +252,25 @@ Installation instructions
 
       Note that configuration parameters can be defined as variables for *any* host in the play &mdash; the host for which you define the configuration parameters is irrelevant.
 
+ 3. To install callhome and configure callhome in the cluster you'll need to provide additional information. It is  recommended to use the `group_vars` inventory file as follows:
+      ```
+      # group_vars/all.yml:
+      ---
+      callhome_params:
+       is_enabled: true
+       customer_name: abc
+       customer_email: abc@abc.com
+       customer_id: 12345
+       customer_country: IN
+       proxy_ip:
+       proxy_port:
+       proxy_user:
+       proxy_password:
+       proxy_location:
+       callhome_server: host-vm1
+       callhome_group1: [host-vm1,host-vm2,host-vm3,host-vm4]
+       callhome_schedule: [daily,weekly]
+      ```
 - #### Modify playbook.yml
 
   The basic playbook.yml looks as follows:
@@ -268,6 +291,10 @@ Installation instructions
       - zimon/precheck
       - zimon/node
       - zimon/cluster
+      - callhome/precheck
+      - callhome/node
+      - callhome/cluster
+      - callhome/postcheck
   ```   
   ---
   **NOTE:**
@@ -358,6 +385,7 @@ If you are assembling your own IBM Spectrum Scale playbook, these roles are avai
 
 - [core gpfs](./roles/core)
 - [gpfs gui](./roles/gui)
+- [gpfs callhome](./roles/callhome)
 
 Cluster Membership
 ------------------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Ansible project with multiple roles(precheck, node, cluster and postcheck) for i
 - [x] Install gcc-c++, kernel-devel, make
 - [x] Install elfutils,elfutils-devel (RHEL8 specific)
 
-#### Core GPFS Cluster build supported features
+#### Core GPFS Cluster supported features
 - [x] Install Core GPFS packages on Linux nodes
 - [x] Install IBM Spectrum Scale license packages on Linux nodes
 - [x] Compile or install pre-compiled Linux kernel extension (mmbuildgpl)
@@ -46,7 +46,7 @@ Ansible project with multiple roles(precheck, node, cluster and postcheck) for i
 - [x] Extend NSDs and file system
 - [x] Add disks to existing file systems
 
-#### GPFS GUI Cluster build supported features
+#### GPFS GUI Cluster supported features
 - [x] Install GPFS GUI packages on GUI designated nodes
 - [x] maximum 3 GUI nodes to be configured
 - [x] Install performance monitoring sensor packages on all Linux nodes
@@ -54,7 +54,7 @@ Ansible project with multiple roles(precheck, node, cluster and postcheck) for i
 - [x] Configure performance monitoring and collectors
 - [ ] Configure HA federated mode collectors
 
-#### GPFS Callhome Cluster build supported features
+#### GPFS Callhome Cluster supported features
 - [x] Install GPFS callhome packages on all cluster nodes
 - [x] Configure callhome
 

--- a/roles/callhome/README.md
+++ b/roles/callhome/README.md
@@ -9,8 +9,8 @@ Role Definition
  
 Prerequisite
 ----------------------------
-- Red Hat Enterprise Linux 7.x, Red Hat Enterprise Linux 8.x, Ubuntu 16.04 LTS, Ubuntu 18.04 LTS, SLES 12, and SLES 15 nodes are supported.
-- Intel x86_64, PowerPC® LE/BE and IBM Z® are supported.
+- Red Hat Enterprise Linux 7.x, Red Hat Enterprise Linux 8.x nodes are supported.
+- Intel x86_64, Power LE/BE are supported.
 - GPFS CCR (Clustered Configuration Repository) must be enabled.
 - The call home node must be able to access the following IP addresses and ports. In the configurations with a proxy, these IP addresses and ports should be accessible over the proxy connection.
   - Host name: esupport.ibm.com
@@ -19,9 +19,6 @@ Prerequisite
 - The parameters required to configure callhome are as follows:
   - Customer information such as customer_name, customer_email, customer_id, customer_country.
   - If proxy is enabled, the proxy information such as proxy_ip, proxy_port, proxy_user, proxy_password.
-- The rpms required for callhome installation are as follows:
-  - gpfs.java-5.0.4-x.x86_64.rpm
-  - gpfs.callhome-ecc-client-5.0.4-x.noarch.rpm
   
 Design
 ---------------------------

--- a/roles/callhome/README.md
+++ b/roles/callhome/README.md
@@ -1,0 +1,85 @@
+Role Definition
+-------------------------------
+- Role name: Callhome
+- Definition:
+  - The call home feature collects files, logs, traces, and details of certain system events from different nodes and services.
+  - The mmcallhome command provides options to configure, enable, run, schedule, and monitor call home related tasks in the IBM Spectrum       Scale cluster.
+  - Information from each node within a call home group is collected and securely uploaded to the IBM® ECuRep server.
+  
+ 
+Prerequisite
+----------------------------
+- Red Hat Enterprise Linux 7.x, Red Hat Enterprise Linux 8.x, Ubuntu 16.04 LTS, Ubuntu 18.04 LTS, SLES 12, and SLES 15 nodes are supported.
+- Intel x86_64, PowerPC® LE/BE and IBM Z® are supported.
+- GPFS CCR (Clustered Configuration Repository) must be enabled.
+- The call home node must be able to access the following IP addresses and ports. In the configurations with a proxy, these IP addresses and ports should be accessible over the proxy connection.
+  - Host name: esupport.ibm.com
+  - IP address: 129.42.56.189, 129.42.60.189, 129.42.54.189
+  - Port number: 443
+- The parameters required to configure callhome are as follows:
+  - Customer information such as customer_name, customer_email, customer_id, customer_country.
+  - If proxy is enabled, the proxy information such as proxy_ip, proxy_port, proxy_user, proxy_password.
+- The rpms required for callhome installation are as follows:
+  - gpfs.java-5.0.4-x.x86_64.rpm
+  - gpfs.callhome-ecc-client-5.0.4-x.noarch.rpm
+  
+Design
+---------------------------
+- Directory Structure:
+  - Path: /ibm-spectrum-scale-install-infra/roles/callhome
+  - Inside the callhome role, there are four more roles to enable microservice architecture:
+    - `Precheck`: This role checks that all the prerequisites are satisfied before installing the callhome rpms. It checks the following things:
+      - Whether callhome is enabled or not.
+      - If callhome is enabled, it checks whether proper customer information is provided or not. This is necessary for proper configuration of callhome. Without this information callhome installation will fail.
+      - Check whether proxy is enabled. If yes, check if all the information required for setting up proxy is defined.
+      - Check if connection can be established to URL https://esupport.ibm.com.
+    - `Node`: This role installs the rpms required for callhome functionality. There are 3 methods to install callhome rpms:  
+      - via local package, requires  scale_install_localpkg_path variable to be set in main playbook.
+      - via remote package, requires scale_install_remotepkg_path variable to be set in main playbook.
+      - via yum repository, requires scale_install_callhome_repository_url variable to be set in main playbook.
+    - `Cluster`: This role configures the callhome functionality. All the parameters required for configuration can be found in `/group_vars`. If callhome is already configured, this step is skipped. Following configurations are made:
+      - Check if callhome is enabled. If yes, skip this step.
+      - Setup the call home proxy configuration if enabled.
+      -	Setup the call home customer configuration.
+      -	Enable callhome.
+      -	Check if callhome group is already created. If yes, skip next step.
+      -	Create callhome group.
+      -	Setup the call home schedule configuration.
+    - `Postcheck`: This role performs the connection test and returns the status.
+
+Implementation
+-------------------------
+- `Precheck`
+  - All the parameters required for setting up callhome is defined in `/ibm-spectrum-scale-install-infra/group_vars/all.yml`. We need to extract these parameters and set them as ansible facts. This is done by the play defined in `/ibm-spectrum-scale-install-infra/roles/callhome/precheck/tasks/storage.yml`. These parameters are extracted in the ansible fact ‘callhome_params’. ‘set_fact’ ansible module is used for this purpose.
+  - All the parameters are then checked if they are defined and not empty. These parameters only need to be checked on callhome server node.
+  
+- `Node`
+  - Installation via local package: rpms are on local machine
+    - File name: install_local_pkg.yml
+    - Path: /ibm-spectrum-scale-install-infra/roles/callhome/node/tasks
+    - This playbook checks whether the package exists, checks for valid checksum, extracts all the rpms and creates a list ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install callhome.
+  - Installation via remote package: rpms are on remote machine
+    - File name: install_remote_pkg.yml
+    - Path: /ibm-spectrum-scale-install-infra/roles/callhome/node/tasks
+    - This playbook checks whether the package exists, checks for valid checksum, extracts all the rpms and creates a list ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install callhome.
+  - Installation via repository: rpms are in yum repo
+    - File name: install_repository.yml
+    - Path: /ibm-spectrum-scale-install-infra/roles/callhome/node/tasks
+    - This playbook configures the yum repo using the URL mentioned in variable scale_install_callhome_repository_url and creates a list ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install callhome.
+  - The installation method is selected in the playbook ‘install.yml’ . Installation method depends on the variables defined.
+    - If  ‘scale_install_callhome_repository_url’ is defined, then the installation method is repository.
+    -	If  ‘scale_install_repository_url’ is undefined and ‘scale_install_remotepkg_path’ is defined, then the installation method is remote.
+    -	If  ‘scale_install_repository_url’ is undefined and ‘scale_install_remotepkg_path’ is undefined and ‘scale_install_localpkg_path’ is defined, then the installation method is local.
+  - Depending on the installation method, appropriate playbook is called for collecting the rpms and rpms are installed. 
+  
+- `Cluster`
+  - To check if callhome is enabled or not, the command used is `mmcallhome capability list -Y`
+  -	For making proxy configuration, the command used is `mmcallhome proxy change  --proxy-location {proxy_location } --proxy-port { proxy_ip } --proxy-username {proxy_user } --proxy-password { proxy_password }`
+  -	For making customer configuration, the command used is `mmcallhome info change --customer-name { customer_name } --customer-id { customer_id } --email {customer_email} --country-code {customer_country }`
+  - For enabling callhome, the command used is `mmcallhome capability enable`
+  -	To check if callhome group is already present or not, the command used is `mmcallhome group list`
+  -	To create a callhome group with a given callhome server, the command used is `mmcallhome group auto --server {callhome_server }`
+  -	To setup callhome schedule, the command used is `mmcallhome schedule add –task [daily/weekly]`
+  
+- `Postcheck`
+  - The command used to test callhome connection is mmcallhome test connection.

--- a/roles/callhome/cluster/defaults/main.yml
+++ b/roles/callhome/cluster/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for cluster
+scale_install_localpkg_tmpdir_path: /tmp
+directory: /usr/lpp/mmfs/bin/

--- a/roles/callhome/cluster/handlers/main.yml
+++ b/roles/callhome/cluster/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for cluster

--- a/roles/callhome/cluster/meta/main.yml
+++ b/roles/callhome/cluster/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: callhome_cluster
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies: []
+# - common

--- a/roles/callhome/cluster/meta/main.yml
+++ b/roles/callhome/cluster/meta/main.yml
@@ -20,4 +20,3 @@ galaxy_info:
     - gpfs
 
 dependencies: []
-# - common

--- a/roles/callhome/cluster/tasks/configure.yml
+++ b/roles/callhome/cluster/tasks/configure.yml
@@ -1,0 +1,83 @@
+#- include_tasks: roles/callhome/precheck/tasks/storage.yml
+- name: configure | Check callhome capabilitiy
+  shell:
+   cmd: mmcallhome capability list -Y | grep enabled
+   chdir: "{{ directory }}"
+  register: scale_callhome_config_status
+  ignore_errors: true
+  failed_when: false
+
+- debug:
+        msg: "{{ scale_callhome_config_status.cmd }}"
+ 
+- block:
+
+  - name: configure | Setup the call home proxy configuration if enabled
+    shell:
+     cmd: mmcallhome proxy change --proxy-location {{callhome_params.proxy_location }} --proxy-port {{ callhome_params.proxy_ip }} --proxy-username {{ callhome_params.proxy_user }} --proxy-password {{ callhome_params.proxy_password }}
+     chdir: "{{ directory }}"
+    when: scale_callhome_proxy_status | bool
+    register: callhome_proxy_status
+
+  - debug:
+     msg: "{{ callhome_proxy_status.cmd }}"
+    when: scale_callhome_proxy_status | bool
+
+  - name: configure| Setup the call home customer configuration
+    shell:
+     cmd: mmcallhome info change --customer-name {{ callhome_params.customer_name }} --customer-id {{ callhome_params.customer_id }} --email {{ callhome_params.customer_email}} --country-code {{ callhome_params.customer_country }}
+     chdir: "{{ directory }}"
+    register: scale_callhome_customer_config
+  
+  - debug:
+     msg: "{{ scale_callhome_customer_config.cmd }}"
+
+  - name: configure| Enable callhome
+    shell:
+     cmd: mmcallhome capability enable
+     chdir: "{{ directory }}"
+     stdin: accept
+    register: scale_callhome_status
+    changed_when: scale_callhome_customer_config|bool
+  
+  - debug:
+     msg: "{{ scale_callhome_status.cmd }}"
+
+  - debug:
+     msg: "Callhome enabled"
+    changed_when: scale_callhome_status|bool
+  
+  - name: configure | Check if callhome group is already created
+    shell:
+     cmd: mmcallhome group list
+     chdir: "{{ directory }}"
+    ignore_errors: true
+    register: scale_callhome_group
+
+  - debug:
+     msg: "{{ scale_callhome_group.cmd }}"
+    
+  - name: configure | Create callhome group
+    shell:
+     cmd: mmcallhome group auto --server {{ callhome_params.callhome_server }}
+     chdir: "{{ directory }}"
+    when: scale_callhome_group.stdout==""
+    register: scale_callhome_group
+
+  - debug:
+     msg: "{{ scale_callhome_group.cmd }}"
+    when: scale_callhome_group|bool
+
+  - name: configure | Setup the call home schedule configuration
+    shell:
+     cmd: mmcallhome schedule add --task {{ item }}
+     chdir: "{{ directory }}"
+    with_items:
+     - "{{ callhome_params.callhome_schedule }}"
+    register: scale_callhome_schedule_status
+
+  - debug:
+     msg: "{{ scale_callhome_schedule_status.cmd }}"
+    when: scale_callhome_schedule_status|bool
+  when: scale_callhome_config_status.stdout==""
+  run_once: true

--- a/roles/callhome/cluster/tasks/main.yml
+++ b/roles/callhome/cluster/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+# tasks file for cluster
+- import_tasks: configure.yml

--- a/roles/callhome/node/defaults/main.yml
+++ b/roles/callhome/node/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+scale_install_callhome_repository_url: http://9.11.84.162/gpfs_rpms/
+
+scale_callhome_rpms:
+  - gpfs.callhome-ecc-client
+  - gpfs.java
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+scale_install_localpkg_tmpdir_path: /tmp
+
+extracted_default_path: "/usr/lpp/mmfs"
+
+gpfs_extracted_path: "{{ extracted_default_path }}/{{ scale_version }}"

--- a/roles/callhome/node/handlers/main.yml
+++ b/roles/callhome/node/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+# handlers file for node
+- name: yum-clean-metadata
+  command: yum clean metadata
+  args:
+   warn: false

--- a/roles/callhome/node/meta/main.yml
+++ b/roles/callhome/node/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: callhome_node
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies: []
+# - common

--- a/roles/callhome/node/tasks/install.yml
+++ b/roles/callhome/node/tasks/install.yml
@@ -1,0 +1,72 @@
+---
+# Install or update RPMs
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - debug:
+       msg: "{{ scale_install_callhome_repository_url }}"
+    - name: install | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_callhome_repository_url is defined
+    - debug:
+            msg: "{{ scale_install_callhome_repository_url }}"
+    - name: install | Check for remotepkg installation method
+      set_fact:
+       scale_installmethod: remote_pkg
+      when:
+      - scale_install_repository_url is undefined
+      - scale_install_remotepkg_path is defined
+
+    - name: install | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: install | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of RPMs
+#
+- name: install | Initialize list of RPMs
+  set_fact:
+    scale_install_all_rpms: []
+
+- name: install | Set the extracted package directory path
+  set_fact:
+    callhome_extracted_path: "{{ gpfs_extracted_path }}/gpfs_rpms"
+
+- name: install | Stat extracted packages directory
+  stat:
+    path: "{{ callhome_extracted_path }}"
+  register: scale_extracted_gpfs_dir
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- debug:
+        msg: "{{ scale_install_all_rpms }}"
+
+- meta: flush_handlers
+
+#
+# Install or update RPMs
+#
+- name: install | Install GPFS Callhome RPMs
+  package:
+    name: "{{ scale_install_all_rpms }}"
+    state: present
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'

--- a/roles/callhome/node/tasks/install_local_pkg.yml
+++ b/roles/callhome/node/tasks/install_local_pkg.yml
@@ -1,0 +1,149 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+      register: scale_install_localpkg
+
+    - name: install | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: install | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: install | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: install | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ callhome_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+    - name: install | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: install | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+#
+# Extract installation package
+#
+- name: install | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ callhome_extracted_path }}"
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ callhome_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: install | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: install | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+- name: install | callhome path
+  set_fact:
+   callhome_url: 'gpfs_rpms/'
+
+- block:
+  - name: install | Find gpfs.java (gpfs.java) RPM
+    find:
+     paths: "{{ callhome_extracted_path }}"
+     patterns: gpfs.java-*.rpm
+     # use_regex: yes
+    register: scale_install_gpfs_java
+
+  - debug:
+          msg: "java rpms for java {{ scale_install_gpfs_java }}"
+
+  - name: install | Check valid GPFS (gpfs.java) RPM
+    assert:
+     that: scale_install_gpfs_java.matched > 0
+     msg: "No GPFS java (gpfs.java) RPM found: {{ callhome_extracted_path }}gpfs.java*.rpm"
+
+  - name: install | Add GPFS java RPM to list
+    vars:
+     current_rpm: "{{ callhome_extracted_path }}/{{ item }}.rpm"
+    set_fact:
+     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_java.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+- block:
+  - name: install | Find gpfs.callhome (gpfs.callhome) RPM
+    find:
+     paths: "{{ callhome_extracted_path }}"
+     patterns: gpfs.callhome-ecc-client*.rpm
+     # use_regex: yes
+    register: scale_install_gpfs_callhome
+  - debug:
+          msg: "{{ scale_install_gpfs_callhome }}"
+
+
+  - name: install | Check valid GPFS (gpfs.callhome) RPM
+    assert:
+     that: scale_install_gpfs_callhome.matched > 0
+     msg: "No GPFS callhome (gpfs.callhome) RPM found: {{ callhome_extracted_path }}gpfs.callhome-ecc-client-{{ scale_version }}*.rpm"
+
+  - name: install | Add GPFS callhome RPM to list
+    vars:
+     current_rpm: "{{ callhome_extracted_path }}/{{ item }}.rpm"
+    set_fact:
+     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_callhome.files.0.path | basename | regex_replace('\\.rpm$', '') }}"

--- a/roles/callhome/node/tasks/install_remote_pkg.yml
+++ b/roles/callhome/node/tasks/install_remote_pkg.yml
@@ -1,0 +1,123 @@
+---
+# Remote package installation method
+
+- name: install | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+  register: scale_install_remotepkg
+
+- name: install | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: install | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: install | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: install | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ callhome_extracted_path }}"
+  register: scale_install_gpfs__rpmdir
+
+- name: install | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: install | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: "{{ callhome_extracted_path }}"
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ callhome_extracted_path }}"
+  register: scale_install_gpfs__rpmdir
+
+- name: install | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs__rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+- name: install | callhome path
+  set_fact:
+   callhome_url: 'gpfs_rpms/'
+   #
+   # find gpfs.java package and add to rpm list
+   #
+- block:
+  - name: install | Find gpfs.java (gpfs.java) RPM
+    find:
+     paths: "{{ callhome_extracted_path }}"
+     patterns: gpfs.java-*.rpm
+     # use_regex: yes
+    register: scale_install_gpfs_java
+
+  - name: install | Check valid GPFS (gpfs.java) RPM
+    assert:
+     that: scale_install_gpfs_java.matched > 0
+     msg: "No GPFS java (gpfs.java) RPM found: {{ callhome_extracted_path }}gpfs.java*.rpm"
+
+  - name: install | Add GPFS java RPM to list
+    vars:
+     current_rpm: "{{ callhome_extracted_path }}/{{ item }}.rpm"
+    set_fact:
+     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_java.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+
+#
+# find gpfs.callhomE package and add it to rpm list
+#
+- block:
+  - name: install | Find gpfs.callhome (gpfs.callhome) RPM
+    find:
+     paths: "{{ callhome_extracted_path }}"
+     patterns: gpfs.callhome-ecc-client*.rpm
+     # use_regex: yes
+    register: scale_install_gpfs_callhome
+
+  - name: install | Check valid GPFS (gpfs.callhome) RPM
+    assert:
+     that: scale_install_gpfs_callhome.matched > 0
+     msg: "No GPFS callhome (gpfs.callhome) RPM found: {{ callhome_extracted_path }}gpfs.callhome-ecc-client-{{ scale_version }}*.rpm"
+
+  - name: install | Add GPFS callhome RPM to list
+    vars:
+     current_rpm: "{{ callhome_extracted_path }}/{{ item }}.rpm"
+    set_fact:
+     cale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_callhome.files.0.path | basename | regex_replace('\\.rpm$', '') }}"

--- a/roles/callhome/node/tasks/install_repository.yml
+++ b/roles/callhome/node/tasks/install_repository.yml
@@ -1,0 +1,27 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: install | Configure Callhome YUM repository
+  yum_repository:
+    name: spectrum-scale-callhome
+    description: IBM Spectrum Scale (ZIMon)
+    baseurl: "{{ scale_install_callhome_repository_url }}"
+    gpgcheck: false
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_callhome_repository_url != 'existing'
+
+#
+# Add GUI RPMs
+#
+- name: install | Add GPFS callhome RPMs to list
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ item ] }}"
+  with_items:
+    - "{{ scale_callhome_rpms }}"
+

--- a/roles/callhome/node/tasks/main.yml
+++ b/roles/callhome/node/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# Install IBM Spectrum Scale (GPFS) Graphical User Interface (GUI)
+
+- import_tasks: install.yml
+  tags: install

--- a/roles/callhome/postcheck/defaults/main.yml
+++ b/roles/callhome/postcheck/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for postcheck

--- a/roles/callhome/postcheck/handlers/main.yml
+++ b/roles/callhome/postcheck/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for postcheck

--- a/roles/callhome/postcheck/meta/main.yml
+++ b/roles/callhome/postcheck/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: callhome_postcheck
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies: []
+# - common

--- a/roles/callhome/postcheck/tasks/check.yml
+++ b/roles/callhome/postcheck/tasks/check.yml
@@ -1,0 +1,17 @@
+---
+- block:
+  - name: configure| Check callhome serivce post configuration
+    shell:
+     cmd: mmcallhome test connection| grep OK
+     chdir: "{{ directory }}"
+    register: scale_callhome_status
+    ignore_errors: true
+
+  - debug:
+     msg: "The call home configuration is not completed successfully.Verify the configuration details and retry"
+    when: scale_callhome_status.stdout==""
+
+  - debug:
+     msg: "Callhome installed and configured."
+    when: scale_callhome_status.stdout!=""
+  when: ansible_hostname== callhome_params.callhome_server

--- a/roles/callhome/postcheck/tasks/main.yml
+++ b/roles/callhome/postcheck/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+# tasks file for postcheck
+- include_tasks: check.yml

--- a/roles/callhome/precheck/defaults/main.yml
+++ b/roles/callhome/precheck/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for precheck

--- a/roles/callhome/precheck/handlers/main.yml
+++ b/roles/callhome/precheck/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for preche
+# handlers file for precheck

--- a/roles/callhome/precheck/handlers/main.yml
+++ b/roles/callhome/precheck/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for preche

--- a/roles/callhome/precheck/meta/main.yml
+++ b/roles/callhome/precheck/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: callhome_precheck
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies: []

--- a/roles/callhome/precheck/tasks/check.yml
+++ b/roles/callhome/precheck/tasks/check.yml
@@ -64,6 +64,3 @@
   - debug:
      msg: "Callhome precheck OK"
     when: ansible_hostname  == callhome_params.callhome_server
-    #- debug:
-    # msg: "{{ inventory_hostname }}"
-     #run_once: true

--- a/roles/callhome/precheck/tasks/check.yml
+++ b/roles/callhome/precheck/tasks/check.yml
@@ -1,0 +1,69 @@
+---
+- block:
+  - name: callhome_precheck | Check if callhome is enabled.
+    assert:
+     that:
+     - callhome_params.is_enabled is defined
+     - callhome_params.is_enabled | bool
+     fail_msg: "Callhome is disabled"
+     success_msg: "Callhome is enabled. Proceeding to check if customer information has been supplied."
+    when:  ansible_hostname  == callhome_params.callhome_server
+
+  - name: callhome_precheck |  Check if customer information has been supplied.
+    assert:
+     that:
+     - callhome_params.customer_name is defined
+     - callhome_params.customer_name| length > 0
+     - callhome_params.customer_email is defined
+     - callhome_params.customer_email| length > 0
+     - callhome_params.customer_id is defined
+     - callhome_params.customer_id| int > 0
+     - callhome_params.customer_country is defined
+     - callhome_params.customer_country| length > 0
+     fail_msg: "Callhome customer information is not defined."
+     success_msg: "Customer information is defined. Proceeding to check if proxy is enabled"
+    when: ansible_hostname  ==  callhome_params.callhome_server
+
+  - name: callhome_precheck | Check if proxy is enabled
+    assert:
+     that:
+     - callhome_params.proxy_ip is defined
+     - callhome_params.proxy_ip|bool
+     - callhome_params.proxy_port is defined
+     - callhome_params.proxy_port|bool
+     fail_msg: "Proxy is not enabled. Proceeding to perform network check"
+     success_msg: "Proxy is enabled. Proceeding to check if proxy user and password is defined"
+    ignore_errors: yes
+    when: ansible_hostname  ==  callhome_params.callhome_server
+    register: scale_callhome_proxy_status
+    failed_when: false
+
+  - name: callhome_precheck | Check if proxy user and passsword is defined
+    assert:
+     that:
+     - callhome_params.proxy_user is defined
+     - callhome_params.proxy_user|bool
+     - callhome_params.proxy_password is defined
+     - callhome_params.proxy_password|bool
+     fail_msg: "Proxy user and password not defined. It is mandatory to define proxy user and password if proxy ip and port is defined"
+     success_msg: "Proxy information is defined.Proceeding to perform network check"
+    when: ansible_hostname  ==  callhome_params.callhome_server and
+          callhome_params.proxy_ip is defined and
+          callhome_params.proxy_port is defined and
+          callhome_params.proxy_ip|bool and
+          callhome_params.proxy_port|bool
+    register: scale_callhome_proxy_status
+
+  - name: callhome_precheck | Checking network connectivity for callhome configuration.
+    uri:
+     url: https://esupport.ibm.com
+     timeout: 10
+     return_content: yes
+    when: ansible_hostname  ==  callhome_params.callhome_server
+
+  - debug:
+     msg: "Callhome precheck OK"
+    when: ansible_hostname  == callhome_params.callhome_server
+    #- debug:
+    # msg: "{{ inventory_hostname }}"
+     #run_once: true

--- a/roles/callhome/precheck/tasks/main.yml
+++ b/roles/callhome/precheck/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+# tasks file for precheck
+- import_tasks: check.yml


### PR DESCRIPTION
Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>

@whowutwut There was some guideline that we can't copy our IP address or other information , so i don't think we should share our UT task execution here . 

@vhu FYI,

COMPONENTS:
•	Role Definition
•	Prerequisite 
•	Design

1. Role Definition:
1)	Role name: Callhome
2)	Definition:
          a)	The call home feature collects files, logs, traces, and details of certain system 
          events from different nodes and services.
          b)	The mmcallhome command provides options to configure, enable, run, schedule, 
          and monitor call home related tasks in the IBM Spectrum Scale cluster.
           c)	Information from each node within a call home group is collected and 
         securely uploaded to the IBM® ECuRep server.

2. Prerequisite:
         1)	Red Hat Enterprise Linux 7.x, Red Hat Enterprise Linux 8.x nodes are supported.
         2)	Intel x86_64, PowerPC® LE/BE and IBM Z® are supported.
         3)	GPFS CCR (Clustered Configuration Repository) must be enabled.
         4)	The call home node must be able to access the following IP addresses and ports. 
                 In the configurations with a proxy, these IP addresses and ports should be accessible 
                  over the proxy connection.
                a)  Host name: esupport
                b)   IP address:
                c)    Port number: 443
         5)  The parameters required to configure are as follows:
               a)  Customer information such as customer_name, customer_email, 
                  customer_id, customer_country.
               b)   If proxy is enabled, the proxy information such as proxy_ip, proxy_port, 
                proxy_user, proxy_password.

          6)   The rpms required for callhome installation are as follows:
                 a)   gpfs.java-5.0.4-x.x86_64.rpm
                 b)   gpfs.callhome-ecc-client-5.0.4-x.noarch.rpm


3. Design:
             1)  Directory Structure:
                  a)  Path: /ibm-spectrum-scale-install-infra /roles/callhome
                  b)  Inside the callhome role, there are four more roles to enable 
                       microservice architecture:
                  i)	Precheck: This role checks that all the prerequisites are satisfied before
                  installing the callhome rpms. It checks the following things:
                         (1)	Whether callhome is enabled or not.
                         (2)	If callhome is enabled, it checks whether proper customer information 
                               is provided or not. This is necessary for proper configuration of 
                               callhome. Without this information callhome installation will fail.
                         (3)	Check whether proxy is enabled. If yes, check if all the information
                                required for setting up proxy is defined.
                         (4)	Check if connection can be established to URL https://esupport.ibm.com.

                   ii)	Node: This role installs the rpms required for callhome functionality. 
                        There are 3 methods to install callhome rpms:
                       (1) via local package, requires  scale_install_localpkg_path variable to be 
                        set in main playbook.
                       (2) via remote package, requires scale_install_remotepkg_path variable to be 
                        set in main playbook.
                       (3) via yum repository, requires scale_install_callhome_repository_url variable 
                      to be set in main playbook.

                   iii)	Cluster: This role configures the callhome functionality. All the 
                        parameters required for configuration can be found in /group_vars. If 
                        callhome is already configured, this step is skipped. Following 
                        configurations are made:
                        (1)	Check if callhome is enabled. If yes, skip this step.
                        (2)	Setup the call home proxy configuration if enabled.
                        (3)	Setup the call home customer configuration.
                        (4)	Enable callhome.
                        (5)	Check if callhome group is already created. If yes, skip next step.
                        (6)	Create callhome group.
                        (7)	Setup the call home schedule configuration.
                        All the steps are run only once.
                 iv)	Postcheck: This role performs the connection test and returns the status.

     Work in progress :
         1. Add support for Ubuntu , SLES OS
     
