### PR TITLE
IBM Spectrum Scale ansible cloud inetgration code

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Installation instructions
       Defining node roles such as `scale_cluster_quorum` and `scale_cluster_manager` is optional. If you do not specify any quorum nodes then the first seven hosts in your inventory are automatically be assigned the quorum role.
 
       ---
- 2. To create NSDs, file systems and node class in the cluster you'll need to provide additional information. It is  recommended to use the `host_vars` inventory file as follows:
+ 2. To create NSDs, file systems and node class in the cluster you'll need to provide additional information. It is  recommended to use the `group_vars` inventory file as follows:
 
       ```
-      # host_vars/scale01:
+      # group_vars/all:
       ---
       scale_storage:
         - filesystem: gpfs01
@@ -164,54 +164,24 @@ Installation instructions
               usage: dataOnly
               pool: data
       ```
-      ```
-      # host_vars/scale02:
-      ---
-      scale_storage:
-        - filesystem: gpfs01
-          disks:
-            - device: /dev/sdb
-              nsd: nsd_3
-              servers: scale02
-              failureGroup: 20
-              usage: metadataOnly
-              pool: system
-            - device: /dev/sdc
-              nsd: nsd_4
-              servers: scale02
-              failureGroup: 20
-              usage: dataOnly
-              pool: data
-      ```
 
       Refer to `man mmchfs` and `man mmchnsd` man pages for a description of these storage parameters.
 
-      The `filesystem` parameter is mandatory, and the `device` parameter is mandatory for each of the file system's `disks`. All other file system and disk parameters are optional. Hence, a minimal file system configuration would look like this:
+      The `filesystem` parameter is mandatory, `servers`, and the `device` parameter is mandatory for each of the file system's `disks`. All other file system and disk parameters are optional. Hence, a minimal file system configuration would look like this:
 
       ```
-      # host_vars/scale01:
+      # group_vars/all:
       ---
       scale_storage:
         - filesystem: gpfs01
           disks:
             - device: /dev/sdb
+              servers: scale01
             - device: /dev/sdc
-      ```
-      ```
-      # host_vars/scale02:
-      ---
-      scale_storage:
-        - filesystem: gpfs01
-          disks:
-            - device: /dev/sdb
-            - device: /dev/sdc
+              servers: scale01,scale02
       ```
 
-      Note that filesystem parameters can be defined as variables for *any* host in the play &mdash; the host for which you define the filesystem parameters is irrelevant. For 
-      disk parameters the host is only relevant if you omit the `servers` variable. When omitting the `servers` variable then the host for which you define the disk is 
-      automatically considered the (only) NSD server for that particular disk.
-
-      > **Important**: `scale_storage` *must* be defined for individual host(s) using `host_vars` inventory files. Do *not* define disk parameters using `group_vars` inventory 
+      > **Important**: `scale_storage` *must* be define using `group_vars` inventory files. Do *not* define disk parameters using `host_vars` inventory 
       files or inline `vars:` in your playbook. Doing so would apply them to all hosts in the group/play, thus defining the same disk multiple times...
 
       Furthermore, Spectrum Scale node classes can be defined on a per-node basis by defining the `scale_nodeclass` variable:

--- a/cloud_playbook.yml
+++ b/cloud_playbook.yml
@@ -1,0 +1,14 @@
+---
+- import_playbook: "set_json_variables.yml"
+
+- hosts: scale_node
+  vars:
+    - scale_version: 5.0.5.0
+    - scale_install_localpkg_path: /root/Spectrum_Scale_Advanced-5.0.5.0-x86_64-Linux-install
+  roles:
+     - core/precheck
+     - core/node
+     - core/cluster
+     - callhome/precheck
+     - callhome/node
+     - callhome/cluster

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -13,7 +13,7 @@
   when: hostvars[inventory_hostname].scale_cluster_manager is undefined
 
 # Cleanup groups from previous play
-- meta: refresh_inventory
+#- meta: refresh_inventory
 
 #
 # Inspect existing cluster and inventory

--- a/roles/core/cluster/tasks/storage.yml
+++ b/roles/core/cluster/tasks/storage.yml
@@ -46,7 +46,7 @@
 - name: storage | Find defined NSDs
   set_fact:
     scale_storage_nsddefs:
-      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | regex_replace('-','_') | default('nsd_' + scale_daemon_nodename + '_' + item.1.device | basename) ] }}"
+      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | default('nsd_' + (item.1.servers | regex_replace('\\W', '_')) + '_' + item.1.device | basename) ] }}"
     scale_storage_nsdservers:
       "{{ scale_storage_nsdservers | default([]) + [ item.1.servers | default(scale_daemon_nodename) ] }}"
   when:

--- a/roles/core/cluster/templates/StanzaFile.j2
+++ b/roles/core/cluster/templates/StanzaFile.j2
@@ -1,18 +1,16 @@
-{% for host in ansible_play_hosts if hostvars[host].scale_storage is defined %}
-{% for fs in hostvars[host].scale_storage if fs.filesystem == current_fs %}
-{% for disk in fs.disks if disk.device is defined and disk.nsd | default('nsd_' + hostvars[host].scale_daemon_nodename + '_' + disk.device | basename) in current_nsds -%}
+{% for fs in scale_storage if fs.filesystem == current_fs %}
+{% for disk in fs.disks if disk.device is defined and disk.nsd | default('nsd_' + disk.servers | replace("-", "_") | replace(".", "_") | replace(",", "_") + '_' + disk.device | basename) in current_nsds -%}
 
-{% set default_nsd = 'nsd_' + hostvars[host].scale_daemon_nodename + '_' + disk.device | basename %}
+{% set default_nsd = 'nsd_' + disk.servers | replace("-", "_") | replace(".", "_") + '_' + disk.device | basename %}
 {% set default_usage = 'dataAndMetadata' if disk.pool | default('system') == 'system' else 'dataOnly' -%}
 
 %nsd:
   device={{ disk.device }}
   nsd={{ disk.nsd | default(default_nsd) }}
-  servers={{ disk.servers | default(hostvars[host].scale_daemon_nodename) }}
+  servers={{ disk.servers }}
   usage={{ disk.usage | default(default_usage) }}
   failureGroup={{ disk.failureGroup | default(-1) }}
   pool={{ disk.pool | default('system') }}
 
-{% endfor %}
 {% endfor %}
 {% endfor %}

--- a/set_json_variables.yml
+++ b/set_json_variables.yml
@@ -1,0 +1,22 @@
+---
+#- name: Create the required groups
+- hosts: localhost
+  connection: local
+
+  tasks:
+  - name: Read all intermediate output from Resource Details
+    include_vars:
+     dir: vars
+     extensions:
+     - json
+
+  - name: Pass all inputs related to creating Spectrum Scale cluster to all nodes
+    add_host:
+     name: "{{ item.fqdn }}"
+     groups: scale_node
+     #var_scale_version: "{{ scale_version }}"
+     scale_storage: "{{ scale_storage }}"
+     scale_cluster_quorum: "{{ item.is_quorum_node  }}"
+     scale_cluster_manager: "{{ item.is_manager_node }}"
+    loop: "{{ node_details }}"
+

--- a/vars/resource_details.json
+++ b/vars/resource_details.json
@@ -48,8 +48,8 @@
        },
        {
         "device": "/dev/sdf",
-        "nsd": "nsd4",
-        "servers": "hogfly-vm1,host-vm2",
+        "nsd": "nsd2",
+        "servers": "host-vm1,host-vm2",
         "usage": dataAndMetadata,
         "pool": system
        }

--- a/vars/resource_details.json
+++ b/vars/resource_details.json
@@ -1,0 +1,59 @@
+{
+  "node_details": [
+    {
+      "fqdn" : host-vm1,
+      "os" : rhel7,
+      "arch" : x86_64,
+      "ip_address" : 192.168.100.101,
+      "is_nfs" : True,
+      "is_smb" : True,
+      "is_hdfs" : False,
+      "is_protocol_node" : True,
+      "is_nsd_server" : False,
+      "is_quorum_node" : True,
+      "is_manager_node" : True,
+      "is_gui_server" : False,
+      "is_callhome_node" : True,
+    },
+    {
+      "fqdn" : host-vm2,
+      "os" : rhel7,
+      "arch" : x86_64,
+      "ip_address" : 192.168.100.102,
+      "is_nfs" : True,
+      "is_smb" : True,
+      "is_hdfs" : False,
+      "is_protocol_node" : True,
+      "is_nsd_server" : False,
+      "is_quorum_node" : True,
+      "is_manager_node" : True,
+      "is_gui_server" : False,
+      "is_callhome_node" : True,
+    } 
+  ],
+  "scale_storage":[
+    {
+      "filesystem": "fs1",
+      "blockSize": 4M,
+      "defaultMetadataReplicas": 1,
+      "defaultDataReplicas": 1,
+      "automaticMountOption": true,
+      "disks": [
+       {
+        "device": "/dev/sdd",
+        "nsd": "nsd1",
+        "servers": "host-vm1",
+	"usage": dataAndMetadata,
+	"pool": system
+       },
+       {
+        "device": "/dev/sdf",
+        "nsd": "nsd4",
+        "servers": "hogfly-vm1,host-vm2",
+        "usage": dataAndMetadata,
+        "pool": system
+       }
+      ]
+    }
+  ]   
+}


### PR DESCRIPTION
This is mainly for Ansible cloud integration support. please let us know if anyone has any concern on this because we are planning to merge this code early next week for cloud team.

    vars - Directory to keep formatted output form terraform
    resource_details.json - Formatted Json file which will act as input/inventory to Spectrum Scale deployment; similar to clusterdefination file that we currently have in installer toolkit.

    Creating host inventory groups with all mandatory node designation and other required variable .
    set_json_variables.yml : This playbook will read json key value pair from vars directory and it will create scale_node host group and ansible role will get executed on scale_node host group in playbook.yml or cloud_playbook.yml etc.

    cloud_playbook.yml : This is similar as playbook.yml , we can keep common playbook.yml for every deployment offering. here we have to include inventory yml file i.e set_json_variables.yml

Now we can use both static inventory or dynamic inventory method through ansible playbook.

To create NSDs, file systems a in the cluster, now we will use group_vars inventory file instead of host_vars inventory file . It is mandate to use the group_vars inventory file .

Currently we are planning to test everything through dev branch then will push to master branch.