### PR TITLE
cloud main playbook execution support with supported role

### DIFF
--- a/cloud_playbook.yml
+++ b/cloud_playbook.yml
@@ -9,6 +9,11 @@
      - core/precheck
      - core/node
      - core/cluster
-     - callhome/precheck
-     - callhome/node
-     - callhome/cluster
+     - gui/precheck
+     - gui/node
+     - gui/cluster
+     - gui/postcheck
+     - zimon/precheck
+     - zimon/node
+     - zimon/cluster
+     - zimon/postcheck


### PR DESCRIPTION
Cloud main playbook i.e cloud_playbook.yml execution support with supported role with core , gui, zimon similar as existing playbook.py.  This playbook introduced for terraform json resource verification but this will get merged into main playbook.yml  once internal team will certify json inventory for all supported functionality.  