### PR TITLE
Spectrum Scale installation package through directory method for clou…

### DIFF
--- a/roles/core/node/defaults/main.yml
+++ b/roles/core/node/defaults/main.yml
@@ -30,6 +30,10 @@ scale_architecture: "{{ ansible_architecture }}"
 ## (local package installation method)
 scale_install_localpkg_tmpdir_path: /tmp
 
+## Specify package extraction path
+extracted_default_path: "/usr/lpp/mmfs"
+gpfs_extracted_path: "{{ extracted_default_path }}/{{ scale_version }}"
+
 ## List of GPFS RPMs to install
 scale_install_gpfs_rpms:
   - gpfs.base

--- a/roles/core/node/tasks/install.yml
+++ b/roles/core/node/tasks/install.yml
@@ -49,7 +49,7 @@
 #
 - name: install | gpfs base path
   set_fact:
-    gpfs_path_url: '/usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms'
+    gpfs_path_url: '{{ gpfs_extracted_path }}/gpfs_rpms'
   when: scale_install_localpkg_path is defined or scale_install_remotepkg_path is defined
 
 - name: install | Initialize list of RPMs

--- a/roles/core/node/tasks/install.yml
+++ b/roles/core/node/tasks/install.yml
@@ -26,6 +26,15 @@
         - scale_install_remotepkg_path is undefined
         - scale_install_localpkg_path is defined
 
+    - name: install | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
     - name: install | Check installation method
       assert:
         that: scale_installmethod is defined
@@ -38,6 +47,11 @@
 #
 # Run chosen installation method to get list of RPMs
 #
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: '/usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms'
+  when: scale_install_localpkg_path is defined or scale_install_remotepkg_path is defined
+
 - name: install | Initialize list of RPMs
   set_fact:
     scale_install_all_rpms: []
@@ -52,7 +66,7 @@
   when: scale_install_gplbin_rpm is defined
 
 - include_tasks: install_license_pkg.yml
-  when: scale_install_remotepkg_path is defined or scale_install_localpkg_path is defined
+  when: scale_install_remotepkg_path is defined or scale_install_localpkg_path is defined or scale_install_directory_pkg_path is defined
 
 - include_tasks: install_license_repository.yml
   when: scale_install_repository_url is defined

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -2,12 +2,12 @@
 # directory package installation method
 
 - block:  ## run_once: true
-    - name: install | Stat local installation package
+    - name: install | Stat directory installation package
       stat:
         path: "{{ scale_install_directory_pkg_path }}"
       register: scale_install_dirpkg
 
-    - name: install | Check local installation package
+    - name: install | Check directory installation package
       assert:
         that: scale_install_dirpkg.stat.exists
         msg: >-
@@ -47,7 +47,7 @@
         mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
 
-- name: install | Extract installation package
+- name: install | Set installation package path
   set_fact:
     dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
 

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -70,15 +70,15 @@
 - name: install | Find GPFS BASE (gpfs.base) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.base-*.{{ scale_architecture }}.rpm
+    patterns: gpfs.base*{{ scale_architecture }}*
   register: scale_install_gpfs_base
 
 - name: install | Check valid GPFS BASE (gpfs.base) RPM
   assert:
     that: scale_install_gpfs_base.matched > 0
     msg: >-
-      No GPFS BASE (gpfs.base) RPM found:
-      {{ dir_path }}/gpfs.base-*.{{ scale_architecture }}.rpm
+      No GPFS BASE (gpfs.base) package found:
+      {{ dir_path }}/gpfs.base*{{ scale_architecture }}*
 
 #
 # Find GPFS gpfs.docs
@@ -86,15 +86,15 @@
 - name: install | Find GPFS docs (gpfs.docs) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.docs-*.noarch.rpm
+    patterns: gpfs.docs*
   register: scale_install_gpfs_doc
 
 - name: install | Check valid GPFS docs (gpfs.docs) RPM
   assert:
     that: scale_install_gpfs_doc.matched > 0
     msg: >-
-      No GPFS docs (gpfs.docs) RPM found:
-      {{ dir_path }}/gpfs.docs-*.noarch.rpm
+      No GPFS docs (gpfs.docs) package found:
+      {{ dir_path }}/gpfs.docs*
 
 #
 # Find GPFS gpfs.msg.en_US
@@ -102,15 +102,15 @@
 - name: install | Find gpfs.msg.en_US (gpfs.msg.en_US) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.msg.en_US-*.noarch.rpm
+    patterns: gpfs.msg.en*
   register: scale_install_gpfs_msg
 
 - name: install | Check valid GPFS (gpfs.msg.en_US) RPM
   assert:
     that: scale_install_gpfs_msg.matched > 0
     msg: >-
-      No GPFS BASE (gpfs.base) RPM found:
-      {{ dir_path }}/gpfs.msg.en_US-*.noarch.rpm
+      No GPFS BASE (gpfs.base) package found:
+      {{ dir_path }}/gpfs.msg.en*
 
 #
 # Find GPFS gpfs.compression
@@ -118,15 +118,14 @@
 - name: install | Find GPFS Compression (gpfs.compression) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.compression-*.{{ scale_architecture }}.rpm
+    patterns: gpfs.compression*{{ scale_architecture }}*
   register: scale_install_gpfs_compression
 
 - name: install | Check valid GPFS Compression(gpfs.compression) RPM
   debug:
-    #that: scale_install_gpfs_compression.matched > 0
     msg: >-
-      No GPFS Compression (gpfs.compression) RPM found:
-      {{ dir_path }}/gpfs.compression-*.{{ scale_architecture }}.rpm
+      No GPFS Compression (gpfs.compression) package found:
+      {{ dir_path }}/gpfs.compression*{{ scale_architecture }}*
   when: scale_install_gpfs_compression.matched < 1
 
 #
@@ -135,41 +134,41 @@
 - name: install | Find Global Security Kit (GSKit) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.gskit-*.{{ scale_architecture }}.rpm
+    patterns: gpfs.gskit*{{ scale_architecture }}*
   register: scale_install_gpfs_gskit
 
 - name: install | Check valid Global Security Kit (GSKit) RPM
   assert:
     that: scale_install_gpfs_gskit.matched > 0
     msg: >-
-      No Global Security Kit (GSKit) RPM found:
-      {{ dir_path }}/gpfs.gskit-*.{{ scale_architecture }}.rpm
+      No Global Security Kit (GSKit) package found:
+      {{ dir_path }}/gpfs.gskit*{{ scale_architecture }}*
 
 #
-# Add GPFS RPMs
+# Add GPFS Packages
 #
 - name: install | Add GPFS RPMs to list
   vars:
-    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+    current_rpm: "{{ dir_path }}/{{ item }}"
   set_fact:
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   with_items:
-    - "{{ scale_install_gpfs_base.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-    - "{{ scale_install_gpfs_doc.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-    - "{{ scale_install_gpfs_msg.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-    - "{{ scale_install_gpfs_gskit.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_base.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_doc.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_msg.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_gskit.files.0.path | basename }}"
 
 - name: install | Add GPFS compression RPMs to list
   vars:
-    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+    current_rpm: "{{ dir_path }}/{{ item }}"
   set_fact:
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
-  with_items: "{{ scale_install_gpfs_compression.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+  with_items: "{{ scale_install_gpfs_compression.files.0.path | basename }}"
   when: scale_install_gpfs_compression.matched == 1
 
 - name: install | Add GPFS RPMs to list (prior to version 5.0.2.0)
   vars:
-    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+    current_rpm: "{{ dir_path }}/{{ item }}"
   set_fact:
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   with_items:
@@ -177,26 +176,26 @@
   when: scale_version is version_compare('5.0.2', '<=')
 
 #
-# Add GPFS RPMs for building GPL module from source
+# Add GPFS Packages for building GPL module from source
 #
 
 - name: install | Find GPFS gpl (gpfs.gpl) RPM
   find:
     paths: "{{ dir_path }}"
-    patterns: gpfs.gpl-*.noarch.rpm
+    patterns: gpfs.gpl*
   register: scale_install_gpfs_gpl
 
 - name: install | Check valid GPFS GPL (gpfs.gpl) RPM
   assert:
     that: scale_install_gpfs_gpl.matched > 0
     msg: >-
-      No GPFS GPL (gpfs.gpl) RPM found:
-      {{ dir_path }}/gpfs.gpl-*.noarch.rpm
+      No GPFS GPL (gpfs.gpl) package found:
+      {{ dir_path }}/gpfs.gpl*
 
 - name: install | Add GPFS RPMs for building GPL module from source to list
   vars:
-    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+    current_rpm: "{{ dir_path }}/{{ item }}"
   set_fact:
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   when: scale_install_gplbin_rpm is undefined
-  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -16,9 +16,17 @@
   run_once: true
   delegate_to: localhost
 
+
+- name: install| Creates default directory
+  file:
+    path: "{{ gpfs_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
 - name: install | Stat extracted packages
   stat:
-    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
   register: scale_install_gpfs_rpmdir
 
 #
@@ -26,30 +34,30 @@
 #
 
 - block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
-    - name: install | Stat temporary directory
+    - name: install | Stat default directory
       stat:
-        path: "{{ scale_install_localpkg_tmpdir_path }}"
+        path: "{{ gpfs_extracted_path }}"
       register: scale_install_localpkg_tmpdir
 
-    - name: install | Check temporary directory
+    - name: install | Check default directory
       assert:
         that:
           - scale_install_localpkg_tmpdir.stat.exists
           - scale_install_localpkg_tmpdir.stat.isdir
         msg: >-
-          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
-          to a temporary directory on the remote system!
+          Please set the variable 'gpfs_extracted_path' to point
+          to a default directory on the remote system!
 
     - name: install | Copy installation package to node
       copy:
         src: "{{ scale_install_directory_pkg_path }}"
-        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        dest: "{{ gpfs_extracted_path }}"
         mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
 
 - name: install | Set installation package path
   set_fact:
-    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    dir_path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
 
 - name: install | gpfs base path
   set_fact:
@@ -114,11 +122,12 @@
   register: scale_install_gpfs_compression
 
 - name: install | Check valid GPFS Compression(gpfs.compression) RPM
-  assert:
-    that: scale_install_gpfs_compression.matched > 0
+  debug:
+    #that: scale_install_gpfs_compression.matched > 0
     msg: >-
       No GPFS Compression (gpfs.compression) RPM found:
       {{ dir_path }}/gpfs.compression-*.{{ scale_architecture }}.rpm
+  when: scale_install_gpfs_compression.matched <= 1
 
 #
 # Find GSKit
@@ -149,7 +158,14 @@
     - "{{ scale_install_gpfs_doc.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
     - "{{ scale_install_gpfs_msg.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
     - "{{ scale_install_gpfs_gskit.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-    - "{{ scale_install_gpfs_compression.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+- name: install | Add GPFS compression RPMs to list
+  vars:
+    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  with_items: "{{ scale_install_gpfs_compression.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+  when: scale_install_gpfs_compression.matched == 1
 
 - name: install | Add GPFS RPMs to list (prior to version 5.0.2.0)
   vars:

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -127,7 +127,7 @@
     msg: >-
       No GPFS Compression (gpfs.compression) RPM found:
       {{ dir_path }}/gpfs.compression-*.{{ scale_architecture }}.rpm
-  when: scale_install_gpfs_compression.matched <= 1
+  when: scale_install_gpfs_compression.matched < 1
 
 #
 # Find GSKit

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -1,0 +1,186 @@
+---
+# directory package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat local installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: install | Check local installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_rpmdir
+
+#
+# Copy installation directory package
+#
+
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+    - name: install | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: install | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: install | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS BASE
+#
+- name: install | Find GPFS BASE (gpfs.base) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.base-*.{{ scale_architecture }}.rpm
+  register: scale_install_gpfs_base
+
+- name: install | Check valid GPFS BASE (gpfs.base) RPM
+  assert:
+    that: scale_install_gpfs_base.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) RPM found:
+      {{ dir_path }}/gpfs.base-*.{{ scale_architecture }}.rpm
+
+#
+# Find GPFS gpfs.docs
+#
+- name: install | Find GPFS docs (gpfs.docs) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.docs-*.noarch.rpm
+  register: scale_install_gpfs_doc
+
+- name: install | Check valid GPFS docs (gpfs.docs) RPM
+  assert:
+    that: scale_install_gpfs_doc.matched > 0
+    msg: >-
+      No GPFS docs (gpfs.docs) RPM found:
+      {{ dir_path }}/gpfs.docs-*.noarch.rpm
+
+#
+# Find GPFS gpfs.msg.en_US
+#
+- name: install | Find gpfs.msg.en_US (gpfs.msg.en_US) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.msg.en_US-*.noarch.rpm
+  register: scale_install_gpfs_msg
+
+- name: install | Check valid GPFS (gpfs.msg.en_US) RPM
+  assert:
+    that: scale_install_gpfs_msg.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) RPM found:
+      {{ dir_path }}/gpfs.msg.en_US-*.noarch.rpm
+
+#
+# Find GPFS gpfs.compression
+#
+- name: install | Find GPFS Compression (gpfs.compression) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.compression-*.{{ scale_architecture }}.rpm
+  register: scale_install_gpfs_compression
+
+- name: install | Check valid GPFS Compression(gpfs.compression) RPM
+  assert:
+    that: scale_install_gpfs_compression.matched > 0
+    msg: >-
+      No GPFS Compression (gpfs.compression) RPM found:
+      {{ dir_path }}/gpfs.compression-*.{{ scale_architecture }}.rpm
+
+#
+# Find GSKit
+#
+- name: install | Find Global Security Kit (GSKit) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.gskit-*.{{ scale_architecture }}.rpm
+  register: scale_install_gpfs_gskit
+
+- name: install | Check valid Global Security Kit (GSKit) RPM
+  assert:
+    that: scale_install_gpfs_gskit.matched > 0
+    msg: >-
+      No Global Security Kit (GSKit) RPM found:
+      {{ dir_path }}/gpfs.gskit-*.{{ scale_architecture }}.rpm
+
+#
+# Add GPFS RPMs
+#
+- name: install | Add GPFS RPMs to list
+  vars:
+    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_base.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_doc.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_msg.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_gskit.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_compression.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+- name: install | Add GPFS RPMs to list (prior to version 5.0.2.0)
+  vars:
+    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  with_items:
+    - "{{ scale_install_add_rpms_pre502 }}"
+  when: scale_version is version_compare('5.0.2', '<=')
+
+#
+# Add GPFS RPMs for building GPL module from source
+#
+
+- name: install | Find GPFS gpl (gpfs.gpl) RPM
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.gpl-*.noarch.rpm
+  register: scale_install_gpfs_gpl
+
+- name: install | Check valid GPFS GPL (gpfs.gpl) RPM
+  assert:
+    that: scale_install_gpfs_gpl.matched > 0
+    msg: >-
+      No GPFS GPL (gpfs.gpl) RPM found:
+      {{ dir_path }}/gpfs.gpl-*.noarch.rpm
+
+- name: install | Add GPFS RPMs for building GPL module from source to list
+  vars:
+    current_rpm: "{{ dir_path }}/{{ item }}.rpm"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  when: scale_install_gplbin_rpm is undefined
+  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename | regex_replace('\\.rpm$', '') }}"

--- a/roles/core/node/tasks/install_license_pkg.yml
+++ b/roles/core/node/tasks/install_license_pkg.yml
@@ -7,15 +7,15 @@
 - name: install | Find GPFS License (gpfs.license) RPM
   find:
     paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.license.*.{{ scale_architecture }}.rpm
+    patterns: gpfs.license*{{ scale_architecture }}*
   register: scale_install_gpfs_license
 
 - name: install | Check valid GPFS License (gpfs.license) RPM
   assert:
     that: scale_install_gpfs_license.matched > 0
     msg: >-
-      No GPFS License (gpfs.license) RPM found:
-      "{{ gpfs_path_url }}/gpfs.license.*.{{ scale_architecture }}.rpm"
+      No GPFS License (gpfs.license) package found:
+      "{{ gpfs_path_url }}/gpfs.license*{{ scale_architecture }}*"
 
 - name: install | Check valid only one GPFS License (gpfs.license) RPM
   assert:
@@ -23,8 +23,8 @@
       - scale_install_gpfs_license.matched > 0
       - scale_install_gpfs_license.matched == 1
     msg: >-
-      More than one GPFS License (gpfs.license) RPM found:
-      "{{ gpfs_path_url }}/gpfs.license.*.{{ scale_architecture }}.rpm"
+      More than one GPFS License (gpfs.license) package found:
+      "{{ gpfs_path_url }}/gpfs.license*{{ scale_architecture }}*"
 
 - name: install | Find GPFS License rpm
   vars:
@@ -38,7 +38,7 @@
 - name: install | Find GPFS Advance (gpfs.adv) RPM
   find:
     paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.adv-*.{{ scale_architecture }}.rpm
+    patterns: gpfs.adv*{{ scale_architecture }}*
   register: scale_install_gpfs_adv
   when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
 
@@ -49,7 +49,7 @@
 - name: install | Find GPFS crypto (gpfs.crypto) RPM
   find:
     paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.crypto-*.{{ scale_architecture }}.rpm
+    patterns: gpfs.crypto*{{ scale_architecture }}*
   register: scale_install_gpfs_crypto
   when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
 
@@ -59,11 +59,11 @@
 #
 - name: install | Add GPFS License RPMs to list
   vars:
-    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}"
   set_fact:
     scale_install_license_rpms: "{{ scale_install_license_rpms + [ current_rpm ] }}"
   with_items:
-    - "{{ scale_install_gpfs_license.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_license.files.0.path | basename }}"
 
 #
 # Add GPFS RPMs
@@ -71,10 +71,10 @@
 - name: install | Add GPFS Dependent License RPMs to list
   vars:
     license_rpm: "{{ scale_install_gpfs_license.files.0.path | basename }}"
-    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}"
   set_fact:
     scale_install_license_rpms: "{{ scale_install_license_rpms + [ current_rpm ] }}"
   with_items:
-    - "{{ scale_install_gpfs_adv.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-    - "{{ scale_install_gpfs_crypto.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_adv.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_crypto.files.0.path | basename }}"
   when: '"gpfs.license.std" not in scale_gpfs_license_rpm'

--- a/roles/core/node/tasks/install_license_pkg.yml
+++ b/roles/core/node/tasks/install_license_pkg.yml
@@ -6,7 +6,7 @@
 #
 - name: install | Find GPFS License (gpfs.license) RPM
   find:
-    paths: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/
+    paths: "{{ gpfs_path_url }}"
     patterns: gpfs.license.*.{{ scale_architecture }}.rpm
   register: scale_install_gpfs_license
 
@@ -15,7 +15,7 @@
     that: scale_install_gpfs_license.matched > 0
     msg: >-
       No GPFS License (gpfs.license) RPM found:
-      /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/gpfs.license.*.{{ scale_architecture }}.rpm
+      "{{ gpfs_path_url }}/gpfs.license.*.{{ scale_architecture }}.rpm"
 
 - name: install | Check valid only one GPFS License (gpfs.license) RPM
   assert:
@@ -24,7 +24,7 @@
       - scale_install_gpfs_license.matched == 1
     msg: >-
       More than one GPFS License (gpfs.license) RPM found:
-      /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/gpfs.license.*.{{ scale_architecture }}.rpm
+      "{{ gpfs_path_url }}/gpfs.license.*.{{ scale_architecture }}.rpm"
 
 - name: install | Find GPFS License rpm
   vars:
@@ -37,7 +37,7 @@
 #
 - name: install | Find GPFS Advance (gpfs.adv) RPM
   find:
-    paths: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/
+    paths: "{{ gpfs_path_url }}"
     patterns: gpfs.adv-*.{{ scale_architecture }}.rpm
   register: scale_install_gpfs_adv
   when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
@@ -48,7 +48,7 @@
 #
 - name: install | Find GPFS crypto (gpfs.crypto) RPM
   find:
-    paths: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/
+    paths: "{{ gpfs_path_url }}"
     patterns: gpfs.crypto-*.{{ scale_architecture }}.rpm
   register: scale_install_gpfs_crypto
   when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
@@ -59,7 +59,7 @@
 #
 - name: install | Add GPFS License RPMs to list
   vars:
-    current_rpm: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/{{ item }}.rpm
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
   set_fact:
     scale_install_license_rpms: "{{ scale_install_license_rpms + [ current_rpm ] }}"
   with_items:
@@ -71,7 +71,7 @@
 - name: install | Add GPFS Dependent License RPMs to list
   vars:
     license_rpm: "{{ scale_install_gpfs_license.files.0.path | basename }}"
-    current_rpm: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/{{ item }}.rpm
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
   set_fact:
     scale_install_license_rpms: "{{ scale_install_license_rpms + [ current_rpm ] }}"
   with_items:

--- a/roles/core/node/tasks/upgrade.yml
+++ b/roles/core/node/tasks/upgrade.yml
@@ -16,7 +16,7 @@
   failed_when: false
 
 - name: update | Find available version
-  shell: rpm -qp /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms/gpfs.base-*.{{ scale_architecture }}.rpm --qf '%{VERSION}-%{RELEASE}\n'
+  shell: rpm -qp "{{ gpfs_path_url }}/gpfs.base-*.{{ scale_architecture }}.rpm" --qf '%{VERSION}-%{RELEASE}\n'
   args:
     warn: false
   register: scale_repo_gpfsversion

--- a/roles/core/precheck/defaults/main.yml
+++ b/roles/core/precheck/defaults/main.yml
@@ -29,17 +29,17 @@ scale_reboot_automatic: false
 
 
 ## Whether or not to exchange SSH keys between nodes
-scale_prepare_exchange_keys: true
+scale_prepare_exchange_keys: false
 
 ## Path to public SSH key - will be generated (if it does not exist) and
 ## exchanged between nodes
 scale_prepare_pubkey_path: /root/.ssh/id_rsa.pub
 
 ## Whether or not enable SSH root login and pubkey authentication
-scale_prepare_enable_ssh_login: true
+scale_prepare_enable_ssh_login: false
 
 ## Whether or not to disable SSH hostkey checking
-scale_prepare_disable_ssh_hostkeycheck: true
+scale_prepare_disable_ssh_hostkeycheck: false
 
 ## Whether or not to disable SELinux
 scale_prepare_disable_selinux: false

--- a/roles/core/precheck/defaults/main.yml
+++ b/roles/core/precheck/defaults/main.yml
@@ -47,7 +47,7 @@ scale_prepare_disable_selinux: false
 ## Whether or not to disable Linux firewalld - if you need to keep firewalld
 ## active then change this variable to 'false' and apply your custom firewall
 ## rules prior to running this role (e.g. as pre_tasks)
-scale_prepare_disable_firewall: true
+scale_prepare_disable_firewall: false
 
 
 ## Temporary directory to copy installation package to

--- a/roles/gui/node/defaults/main.yml
+++ b/roles/gui/node/defaults/main.yml
@@ -30,3 +30,7 @@ scale_gui_hide_tip_callhome: false
 
 ## Compute RPM version from Spectrum Scale version
 scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+extracted_default_path: "/usr/lpp/mmfs"
+gpfs_extracted_path: "{{ extracted_default_path }}/{{ scale_version }}"

--- a/roles/gui/node/tasks/install.yml
+++ b/roles/gui/node/tasks/install.yml
@@ -43,7 +43,7 @@
 #
 - name: install | gpfs base path
   set_fact:
-    gpfs_path_url: '/usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms'
+    gpfs_path_url: '{{ gpfs_extracted_path }}/gpfs_rpms'
   when: scale_install_localpkg_path is defined or scale_install_remotepkg_path is defined
 
 - name: install | Initialize list of RPMs

--- a/roles/gui/node/tasks/install.yml
+++ b/roles/gui/node/tasks/install.yml
@@ -20,6 +20,15 @@
         - scale_install_remotepkg_path is undefined
         - scale_install_localpkg_path is defined
 
+    - name: install | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
     - name: install | Check installation method
       assert:
         that: scale_installmethod is defined
@@ -32,6 +41,11 @@
 #
 # Run chosen installation method to get list of RPMs
 #
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: '/usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms'
+  when: scale_install_localpkg_path is defined or scale_install_remotepkg_path is defined
+
 - name: install | Initialize list of RPMs
   set_fact:
     scale_install_all_rpms: []

--- a/roles/gui/node/tasks/install_dir_pkg.yml
+++ b/roles/gui/node/tasks/install_dir_pkg.yml
@@ -2,12 +2,12 @@
 # Dir package installation method
 
 - block:  ## run_once: true
-    - name: install | Stat local installation package
+    - name: install | Stat directory installation package
       stat:
         path: "{{ scale_install_directory_pkg_path }}"
       register: scale_install_dirpkg
 
-    - name: install | Check local installation package
+    - name: install | Check directory installation package
       assert:
         that: scale_install_dirpkg.stat.exists
         msg: >-
@@ -46,7 +46,7 @@
         mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
 
-- name: install | Extract installation package
+- name: install | Set installation package path
   set_fact:
     dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
 

--- a/roles/gui/node/tasks/install_dir_pkg.yml
+++ b/roles/gui/node/tasks/install_dir_pkg.yml
@@ -1,0 +1,99 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat local installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: install | Check local installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_rpmdir
+
+#
+# Copy installation directory package to /tmp
+#
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+    - name: install | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: install | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: install | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS GUI
+#
+- block:  ## when: host is defined as a gui node
+    - name: install | Find GPFS GUI (gpfs.gui) RPM
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.gui-*.noarch.rpm
+      register: scale_install_gpfs_gui
+
+    - name: install | Check valid GPFS GUI (gpfs.gui) RPM
+      assert:
+        that: scale_install_gpfs_gui.matched > 0
+        msg: >-
+          No GPFS GUI (gpfs.gui) RPM found:
+          "{{ gpfs_path_url }}/gpfs_rpms/gpfs.gui-*.noarch.rpm"
+    #
+    # Find GPFS gpfs.java
+    #
+    - name: install | Find GPFS java (gpfs.java) RPM
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.java-*.{{ scale_architecture }}.rpm
+      register: scale_install_gpfs_java
+
+    - name: install | Check valid GPFS java (gpfs.java) RPM
+      assert:
+        that: scale_install_gpfs_java.matched > 0
+        msg: >-
+          No GPFS java (gpfs.java) RPM found:
+          "{{ gpfs_path_url }}/gpfs.java-*.{{ scale_architecture }}.rpm"
+
+    - name: install | Add GPFS GUI RPMs to list
+      vars:
+        current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+      set_fact:
+        scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_gui.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+        - "{{ scale_install_gpfs_java.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+  when: scale_cluster_gui | bool

--- a/roles/gui/node/tasks/install_dir_pkg.yml
+++ b/roles/gui/node/tasks/install_dir_pkg.yml
@@ -16,39 +16,46 @@
   run_once: true
   delegate_to: localhost
 
+- name: install| Creates default directory
+  file:
+    path: "{{ gpfs_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
 - name: install | Stat extracted packages
   stat:
-    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
   register: scale_install_gpfs_rpmdir
 
 #
-# Copy installation directory package to /tmp
+# Copy installation directory package to default
 #
 - block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
-    - name: install | Stat temporary directory
+    - name: install | Stat default directory
       stat:
-        path: "{{ scale_install_localpkg_tmpdir_path }}"
+        path: "{{ gpfs_extracted_path }}"
       register: scale_install_localpkg_tmpdir
 
-    - name: install | Check temporary directory
+    - name: install | Check default directory
       assert:
         that:
           - scale_install_localpkg_tmpdir.stat.exists
           - scale_install_localpkg_tmpdir.stat.isdir
         msg: >-
-          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
-          to a temporary directory on the remote system!
+          Please set the variable 'gpfs_extracted_path' to point
+          to a default directory on the remote system!
 
     - name: install | Copy installation package to node
       copy:
         src: "{{ scale_install_directory_pkg_path }}"
-        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        dest: "{{ gpfs_extracted_path }}"
         mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
 
 - name: install | Set installation package path
   set_fact:
-    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    dir_path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
 
 - name: install | gpfs base path
   set_fact:

--- a/roles/gui/node/tasks/install_dir_pkg.yml
+++ b/roles/gui/node/tasks/install_dir_pkg.yml
@@ -69,38 +69,38 @@
     - name: install | Find GPFS GUI (gpfs.gui) RPM
       find:
         paths: "{{ gpfs_path_url }}"
-        patterns: gpfs.gui-*.noarch.rpm
+        patterns: gpfs.gui*
       register: scale_install_gpfs_gui
 
     - name: install | Check valid GPFS GUI (gpfs.gui) RPM
       assert:
         that: scale_install_gpfs_gui.matched > 0
         msg: >-
-          No GPFS GUI (gpfs.gui) RPM found:
-          "{{ gpfs_path_url }}/gpfs_rpms/gpfs.gui-*.noarch.rpm"
+          No GPFS GUI (gpfs.gui) package found:
+          "{{ gpfs_path_url }}/gpfs_rpms/gpfs.gui*"
     #
     # Find GPFS gpfs.java
     #
     - name: install | Find GPFS java (gpfs.java) RPM
       find:
         paths: "{{ gpfs_path_url }}"
-        patterns: gpfs.java-*.{{ scale_architecture }}.rpm
+        patterns: gpfs.java*{{ scale_architecture }}*
       register: scale_install_gpfs_java
 
     - name: install | Check valid GPFS java (gpfs.java) RPM
       assert:
         that: scale_install_gpfs_java.matched > 0
         msg: >-
-          No GPFS java (gpfs.java) RPM found:
-          "{{ gpfs_path_url }}/gpfs.java-*.{{ scale_architecture }}.rpm"
+          No GPFS java (gpfs.java) package found:
+          "{{ gpfs_path_url }}/gpfs.java*{{ scale_architecture }}*"
 
     - name: install | Add GPFS GUI RPMs to list
       vars:
-        current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+        current_rpm: "{{ gpfs_path_url }}/{{ item }}"
       set_fact:
         scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
       with_items:
-        - "{{ scale_install_gpfs_gui.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
-        - "{{ scale_install_gpfs_java.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+        - "{{ scale_install_gpfs_gui.files.0.path | basename }}"
+        - "{{ scale_install_gpfs_java.files.0.path | basename }}"
 
   when: scale_cluster_gui | bool

--- a/roles/zimon/node/defaults/main.yml
+++ b/roles/zimon/node/defaults/main.yml
@@ -34,3 +34,7 @@ scale_cluster_gui: false
 
 ## Compute RPM version from Spectrum Scale version
 scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+extracted_default_path: "/usr/lpp/mmfs"
+gpfs_extracted_path: "{{ extracted_default_path }}/{{ scale_version }}"

--- a/roles/zimon/node/tasks/install.yml
+++ b/roles/zimon/node/tasks/install.yml
@@ -11,6 +11,9 @@
         scale_installmethod: repository
       when:
         - scale_install_zimon_repository_url is defined
+        - scale_install_localpkg_path is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
 
     - name: install | Check for localpkg installation method
       set_fact:
@@ -18,7 +21,17 @@
       when:
         - scale_install_repository_url is undefined
         - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
         - scale_install_localpkg_path is defined
+
+    - name: install | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
 
     - name: install | Check installation method
       assert:

--- a/roles/zimon/node/tasks/install_dir_pkg.yml
+++ b/roles/zimon/node/tasks/install_dir_pkg.yml
@@ -2,12 +2,12 @@
 # Dir package installation method
 
 - block:  ## run_once: true
-    - name: install | Stat local installation package
+    - name: install | Stat directory installation package
       stat:
         path: "{{ scale_install_directory_pkg_path }}"
       register: scale_install_dirpkg
 
-    - name: install | Check local installation package
+    - name: install | Check directory installation package
       assert:
         that: scale_install_dirpkg.stat.exists
         msg: >-

--- a/roles/zimon/node/tasks/install_dir_pkg.yml
+++ b/roles/zimon/node/tasks/install_dir_pkg.yml
@@ -16,39 +16,46 @@
   run_once: true
   delegate_to: localhost
 
+- name: install| Creates default directory
+  file:
+    path: "{{ gpfs_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+ 
 - name: install | Stat extracted packages
   stat:
-    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
   register: scale_install_gpfs_rpmdir
 
 #
-# Copy installation directory package to /tmp
+# Copy installation directory package to default
 #
 - block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
-    - name: install | Stat temporary directory
+    - name: install | Stat default directory
       stat:
-        path: "{{ scale_install_localpkg_tmpdir_path }}"
+        path: "{{ gpfs_extracted_path }}"
       register: scale_install_localpkg_tmpdir
 
-    - name: install | Check temporary directory
+    - name: install | Check default directory
       assert:
         that:
           - scale_install_localpkg_tmpdir.stat.exists
           - scale_install_localpkg_tmpdir.stat.isdir
         msg: >-
-          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
-          to a temporary directory on the remote system!
+          Please set the variable 'gpfs_extracted_path' to point
+          to a default directory on the remote system!
 
     - name: install | Copy installation package to node
       copy:
         src: "{{ scale_install_directory_pkg_path }}"
-        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        dest: "{{ gpfs_extracted_path }}"
         mode: a+x
-  #when: not scale_install_gpfs_rpmdir.stat.exists
+  when: not scale_install_gpfs_rpmdir.stat.exists
 
 - name: install | Extract installation package
   set_fact:
-    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+    dir_path: "{{ gpfs_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
 
 - name: install | gpfs base path
   set_fact:

--- a/roles/zimon/node/tasks/install_dir_pkg.yml
+++ b/roles/zimon/node/tasks/install_dir_pkg.yml
@@ -72,23 +72,23 @@
     - name: install | Find gpfs.collector (gpfs.collector) RPM
       find:
         paths: "{{ gpfs_path_url }}"
-        patterns: gpfs.gss.pmcollector-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm
+        patterns: gpfs.gss.pmcollector*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*
       register: scale_install_gpfs_collector
 
     - name: install | Check valid GPFS (gpfs.collector) RPM
       assert:
         that: scale_install_gpfs_collector.matched > 0
         msg: >-
-          No GPFS collector (gpfs.gss.collector) RPM found:
-          "{{ gpfs_path_url }}/gpfs.gss.pmcollector-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm"
+          No GPFS collector (gpfs.gss.collector) package found:
+          "{{ gpfs_path_url }}/gpfs.gss.pmcollector*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*"
 
     - name: install | Add GPFS zimon collector RPMs to list
       vars:
-        current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+        current_rpm: "{{ gpfs_path_url }}/{{ item }}"
       set_fact:
         scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
       with_items:
-        - "{{ scale_install_gpfs_collector.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+        - "{{ scale_install_gpfs_collector.files.0.path | basename }}"
 
   when: (scale_zimon_collector | bool) or (scale_cluster_gui | bool)
 
@@ -98,20 +98,20 @@
 - name: install | Find gpfs.gss.pmsensors (gpfs.gss.pmsensors) RPM
   find:
     paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.gss.pmsensors-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm
+    patterns: gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*
   register: scale_install_gpfs_pmsensors
 
 - name: install | Check valid GPFS (gpfs.gss.pmsensors) RPM
   assert:
     that: scale_install_gpfs_pmsensors.matched > 0
     msg: >-
-      No GPFS pmsensors (gpfs.gss.pmsensors) RPM found:
-      "{{ gpfs_path_url }}/gpfs.gss.pmsensors-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm"
+      No GPFS pmsensors (gpfs.gss.pmsensors) package found:
+      "{{ gpfs_path_url }}/gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*"
 
 - name: install | Add GPFS zimon sensors RPMs to list
   vars:
-    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}"
   set_fact:
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   with_items:
-    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename }}"

--- a/roles/zimon/node/tasks/install_dir_pkg.yml
+++ b/roles/zimon/node/tasks/install_dir_pkg.yml
@@ -1,0 +1,110 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat local installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: install | Check local installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_rpmdir
+
+#
+# Copy installation directory package to /tmp
+#
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+    - name: install | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: install | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  #when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: install | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find Zimon collector
+#
+- block:  ## when: host is defined as a gui node
+    #
+    # Find GPFS gpfs.collector
+    #
+    - name: install | Find gpfs.collector (gpfs.collector) RPM
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.gss.pmcollector-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm
+      register: scale_install_gpfs_collector
+
+    - name: install | Check valid GPFS (gpfs.collector) RPM
+      assert:
+        that: scale_install_gpfs_collector.matched > 0
+        msg: >-
+          No GPFS collector (gpfs.gss.collector) RPM found:
+          "{{ gpfs_path_url }}/gpfs.gss.pmcollector-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm"
+
+    - name: install | Add GPFS zimon collector RPMs to list
+      vars:
+        current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+      set_fact:
+        scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_collector.files.0.path | basename | regex_replace('\\.rpm$', '') }}"
+
+  when: (scale_zimon_collector | bool) or (scale_cluster_gui | bool)
+
+#
+# Find GPFS gpfs.gss.pmsensors
+#
+- name: install | Find gpfs.gss.pmsensors (gpfs.gss.pmsensors) RPM
+  find:
+    paths: "{{ gpfs_path_url }}"
+    patterns: gpfs.gss.pmsensors-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm
+  register: scale_install_gpfs_pmsensors
+
+- name: install | Check valid GPFS (gpfs.gss.pmsensors) RPM
+  assert:
+    that: scale_install_gpfs_pmsensors.matched > 0
+    msg: >-
+      No GPFS pmsensors (gpfs.gss.pmsensors) RPM found:
+      "{{ gpfs_path_url }}/gpfs.gss.pmsensors-*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}.rpm"
+
+- name: install | Add GPFS zimon sensors RPMs to list
+  vars:
+    current_rpm: "{{ gpfs_path_url }}/{{ item }}.rpm"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename | regex_replace('\\.rpm$', '') }}"


### PR DESCRIPTION
Spectrum Scale installation package through directory method for cloud deployment.

Now we are allowing user to provide directory as a input in addition to local /remote/repo installation method . 

Eg: `- scale_install_directory_pkg_path: /root/rpms/gpfs_rpms`

User needs to keep all required rpms inside user provided directory input. 

Currently we are going to support this method for core gpfs , license , gui and zimon rpms. 

I was planning to do some more code refactoring but then it will introduce huge regression for cloud release. so i tried not to touch existing code much.  

1. This implementation will allow user to provide single unique directory to install core 
    gpfs, zimon and gui component.
   Eg: `- scale_install_directory_pkg_path: /root/rpms/gpfs_rpms`
2. Playbook will create default directory on all gpfs cluster node if its not exist i.e
    `/usr/lpp/mmfs/<scale_version>`
3. Playbook will copy  user provided directory to default directory .
  ` /usr/lpp/mmfs/<scale_version>/<gpfs_rpms>`
4. Playbook will install  all required gpfs rpms from , 
    ` /usr/lpp/mmfs/<scale_version>/<gpfs_rpms>`
5. Playbook will skip `gpfs.compression` package installation if user has not kept inside 
   user input directory. 

Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>