### PR TITLE
If nsd is not defined, this task will fail and not use the default

### DIFF
--- a/roles/core/cluster/tasks/storage.yml
+++ b/roles/core/cluster/tasks/storage.yml
@@ -46,7 +46,7 @@
 - name: storage | Find defined NSDs
   set_fact:
     scale_storage_nsddefs:
-      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | regex_replace('-','_') | default('nsd_' + scale_daemon_nodename + '_' + item.1.device | basename) ] }}"
+      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | default('nsd_' + scale_daemon_nodename + '_' + item.1.device | basename) ] }}"
     scale_storage_nsdservers:
       "{{ scale_storage_nsdservers | default([]) + [ item.1.servers | default(scale_daemon_nodename) ] }}"
   when:


### PR DESCRIPTION
This fixes the issues in #18 for the **master branch**.  For the dev branch, it seems like the logic has changed and no longer has the regex_replace.  

I want to re-stabilize the master code branch so it will work if nsd names are not specified, since there's no planned date to merge dev -> master. 