### PR TITLE
Fixed default nsd name issue i.e #24

### DIFF
--- a/roles/core/cluster/tasks/storage.yml
+++ b/roles/core/cluster/tasks/storage.yml
@@ -46,7 +46,7 @@
 - name: storage | Find defined NSDs
   set_fact:
     scale_storage_nsddefs:
-      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | default('nsd_' + (item.1.servers | regex_replace('\\W', '_')) + '_' + item.1.device | basename) ] }}"
+      "{{ scale_storage_nsddefs | default([]) + [ item.1.nsd | default('nsd_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) + '_' + item.1.device | basename) ] }}"
     scale_storage_nsdservers:
       "{{ scale_storage_nsdservers | default([]) + [ item.1.servers | default(scale_daemon_nodename) ] }}"
   when:

--- a/roles/core/cluster/templates/StanzaFile.j2
+++ b/roles/core/cluster/templates/StanzaFile.j2
@@ -1,7 +1,7 @@
 {% for fs in scale_storage if fs.filesystem == current_fs %}
-{% for disk in fs.disks if disk.device is defined and disk.nsd | default('nsd_' + disk.servers | replace("-", "_") | replace(".", "_") | replace(",", "_") + '_' + disk.device | basename) in current_nsds -%}
+{% for disk in fs.disks if disk.device is defined and disk.nsd | default('nsd_' + disk.servers.split(',')[0] | replace("-", "_") | replace(".", "_") | replace(",", "_") + '_' + disk.device | basename) in current_nsds -%}
 
-{% set default_nsd = 'nsd_' + disk.servers | replace("-", "_") | replace(".", "_") + '_' + disk.device | basename %}
+{% set default_nsd = 'nsd_' + disk.servers.split(',')[0] | replace("-", "_") | replace(".", "_") + '_' + disk.device | basename %}
 {% set default_usage = 'dataAndMetadata' if disk.pool | default('system') == 'system' else 'dataOnly' -%}
 
 %nsd:


### PR DESCRIPTION
NSD creation was failing if user is not defining nsd names in the goup_vars/all inventory.  this issue was mainly happening when nsd disks contain multiple nsd server. 



Signed-off-by: Rajan Mishra rajanmis@in.ibm.com