### PR TITLE
Allow CentOS systems running the playbook to work, by setting:  zimon_url 

### DIFF
--- a/roles/zimon/node/tasks/install_local_pkg.yml
+++ b/roles/zimon/node/tasks/install_local_pkg.yml
@@ -100,7 +100,9 @@
 - name: install | zimon path
   set_fact:
     zimon_url: 'zimon_rpms/rhel7/'
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
+  when:
+    - ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
+    - ansible_distribution_major_version == '7'
 
 - name: install | zimon path
   set_fact:


### PR DESCRIPTION
When running the playbook roles on an CentOS 7.x cluster, `zimon_url` is not defined in the set_facts.  

While I know CentOS is not the priority support OS on our current roadmap, by making this simple change, we can allow community members to use these playbooks on CentOS operating systems.  