### PR TITLE
Define scale version through gpfs.base package if user has not defined.

### DIFF
--- a/cloud_playbook.yml
+++ b/cloud_playbook.yml
@@ -1,10 +1,11 @@
 ---
+# This file is mandatory to import and it will load scale 
+# inventory variable form vars/scale_clusterdefinition.json.
 - import_playbook: "set_json_variables.yml"
 
 - hosts: scale_node
   vars:
-    - scale_version: 5.0.5.0
-    - scale_install_localpkg_path: /root/Spectrum_Scale_Advanced-5.0.5.0-x86_64-Linux-install
+    - scale_install_directory_pkg_path: /root/scale_rpms
   roles:
      - core/precheck
      - core/node

--- a/roles/core/common/tasks/check.yml
+++ b/roles/core/common/tasks/check.yml
@@ -1,6 +1,48 @@
 ---
 # Sanity check of configuration variables
 
+- block:
+    - block:
+        - name: common | Find available scale version
+          shell: rpm -qp "{{ scale_install_directory_pkg_path }}/gpfs.base-*.{{ scale_architecture }}.rpm"
+                 --qf '%{VERSION}.%{RELEASE}\n' | cut -d '.' -f -4
+          args:
+             warn: false
+          register: scale_gpfsversion
+          changed_when: false
+
+        - name: check | Set scale version
+          set_fact:
+            scale_version: "{{ scale_gpfsversion.stdout }}"
+      when: scale_install_directory_pkg_path is defined
+
+    - block:
+        - name: check | Set package installation method
+          set_fact:
+            scale_package: "{{ scale_install_localpkg_path | basename }}"
+          when: scale_install_localpkg_path is defined
+
+        - name: check | Set package installation method
+          set_fact:
+            scale_package: "{{ scale_install_remotepkg_path | basename }}"
+          when: scale_install_remotepkg_path is defined
+
+        - name: commin | Find available scale version
+          shell: "echo {{ scale_package }} | cut -d '-' -f 2"
+          args:
+           warn: false
+          register: scale_se_gpfsversion
+          changed_when: false
+
+        - name: check | Set default scale version
+          set_fact:
+            scale_version: "{{ scale_se_gpfsversion.stdout }}"
+
+      when: scale_install_localpkg_path is defined or scale_install_remotepkg_path is defined
+  when: scale_version is undefined
+  run_once: true
+  delegate_to: localhost
+
 - name: check | Check Spectrum Scale version
   assert:
     that:

--- a/roles/core/common/tasks/check.yml
+++ b/roles/core/common/tasks/check.yml
@@ -27,7 +27,7 @@
             scale_package: "{{ scale_install_remotepkg_path | basename }}"
           when: scale_install_remotepkg_path is defined
 
-        - name: commin | Find available scale version
+        - name: common | Find available scale version
           shell: "echo {{ scale_package }} | cut -d '-' -f 2"
           args:
            warn: false


### PR DESCRIPTION
Now playbook will internally define gpfs version , i have added this implementation for local installation method and directory method. 

Author: Rajan Mishra <rajanmis@in.ibm.com>