### PR TITLE
[DEV]Fix mmbuildgpl prereq package installation issue with matched ke…

### DIFF
--- a/roles/core/node/defaults/main.yml
+++ b/roles/core/node/defaults/main.yml
@@ -68,8 +68,9 @@ scale_install_gplbin_prereqs:
 
 ## List of RPMs to install when building Linux kernel extension from source
 scale_build_gplsrc_prereqs:
+  - kernel-devel-{{ ansible_kernel }}
+  - kernel-headers-{{ ansible_kernel }}
   - gcc-c++
-  - kernel-devel
   - make
 
 ## List of RPMs to install specific to rhel8 when building Linux kernel extension from source


### PR DESCRIPTION
gpfs rpm pre-req install (such as kernel-devel, headers) on cloud picks to new kernel versions, which causes mmbuildgpl to fail #64

Author: Rajan Mishra <rajanmis@in.ibm.com>