### PR TITLE
Fix the invalid JSON formatting in the sample file 

### DIFF
--- a/vars/scale_clusterdefinition.json
+++ b/vars/scale_clusterdefinition.json
@@ -1,26 +1,26 @@
 {
   "node_details": [
     {
-      "fqdn" : host-vm1,
-      "ip_address" : 192.168.100.101,
-      "is_nsd_server": True,
-      "is_quorum_node" : True,
-      "is_manager_node" : True,
-      "is_gui_server" : False,
+      "fqdn" : "host-vm1",
+      "ip_address" : "192.168.100.101",
+      "is_nsd_server": "True",
+      "is_quorum_node" : "True",
+      "is_manager_node" : "True",
+      "is_gui_server" : "False"
     },
     {
-      "fqdn" : host-vm2,
-      "ip_address" : 192.168.100.102,
-      "is_nsd_server": True,
-      "is_quorum_node" : True,
-      "is_manager_node" : True,
-      "is_gui_server" : False,
-    },
+      "fqdn" : "host-vm2",
+      "ip_address" : "192.168.100.102",
+      "is_nsd_server": "True",
+      "is_quorum_node" : "True",
+      "is_manager_node" : "True",
+      "is_gui_server" : "False"
+    }
   ],
   "scale_storage":[
     {
       "filesystem": "fs1",
-      "blockSize": 4M,
+      "blockSize": "4M",
       "defaultDataReplicas": 1,
       "defaultMountPoint": "/mnt/fs1",
       "disks": [


### PR DESCRIPTION
I started playing with the JSON file to match it to my environment  and noticed that the example has invalid JSON when running through an online linting tool, like https://jsonlint.com/

Until we get a linter in place, just manually fix it for now so we provide a solid starting point.

After pasting the changes into the linter: 
![image](https://user-images.githubusercontent.com/10049070/78696929-150d2300-78ce-11ea-99cb-0c4811844391.png)
