### PR TITLE
Profile configuration support code for mmcrcluster

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -52,3 +52,13 @@ scale_storage_filesystem_defaults:
   ## for an existing NSD header (dangerous!)
   overwriteNSDs: false
 # defaults file for node
+
+# Specifies a predefined profile of attributes to be applied.
+# System-defined profiles are located in /usr/lpp/mmfs/profiles/. 
+# The following system-defined profile names are accepted: 
+# gpfsprotocoldefaults and gpfsprotocolrandomio
+# eg: If you want to apply gpfsprotocoldefaults then specify scale_cluster_profile_name: gpfsprotocoldefaults
+scale_cluster_profile_name: None
+
+# System-defined profiles are located in /usr/lpp/mmfs/profiles/
+scale_cluster_profile_dir_path: /usr/lpp/mmfs/profiles/

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -72,10 +72,31 @@
         src: NewNodeFile.j2
         dest: /var/tmp/NodeFile
 
-    - name: cluster | Create new cluster
-      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }}
-      notify: accept-licenses
+    - name: check | Stat GPFS profile file
+      find:
+        paths: "{{ scale_cluster_profile_dir_path }}"
+        patterns: "{{ scale_cluster_profile_name }}.profile"
+      register: stat_profile_result
 
+    - name: install | Initialize gpfs profile
+      set_fact:
+         profile_type: ""
+
+    - name: install | Set gpfs profile if it is defined
+      set_fact:
+         profile_type: "--profile {{ scale_cluster_profile_name }}"
+      when: 
+        - stat_profile_result.matched == 1
+        - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+
+    - name: cluster | Create new cluster
+      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }} {{ profile_type }}
+      notify: accept-licenses
+      register: mmcrcluster_results
+
+    - debug:
+         msg: "{{ mmcrcluster_results.cmd }}"
+     
     - name: cluster | Cleanup new cluster NodeFile
       file:
         path: /var/tmp/NodeFile

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -184,20 +184,3 @@
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   when: scale_install_gplbin_rpm is undefined
   with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"
-
-#
-# Find ibm_cloud_workflows
-#
-- name: install | Find workflows package
-  find:
-    paths: "{{ dir_path }}"
-    patterns: ibm_cloud_workflows*
-  register: scale_install_cloud_workflows
-
-- name: install | Add workflows package from source to list
-  vars:
-    current_rpm: "{{ dir_path }}/{{ item }}"
-  set_fact:
-    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
-  with_items: "{{ scale_install_cloud_workflows.files.0.path | basename }}"
-  when: scale_install_cloud_workflows.matched == 1

--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -184,3 +184,20 @@
     scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
   when: scale_install_gplbin_rpm is undefined
   with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"
+
+#
+# Find ibm_cloud_workflows
+#
+- name: install | Find workflows package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: ibm_cloud_workflows*
+  register: scale_install_cloud_workflows
+
+- name: install | Add workflows package from source to list
+  vars:
+    current_rpm: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ current_rpm ] }}"
+  with_items: "{{ scale_install_cloud_workflows.files.0.path | basename }}"
+  when: scale_install_cloud_workflows.matched == 1


### PR DESCRIPTION
```
# Specifies a predefined profile of attributes to be applied.
# System-defined profiles are located in /usr/lpp/mmfs/profiles/. 
# The following system-defined profile names are accepted: 
# gpfsprotocoldefaults and gpfsprotocolrandomio
# eg: If you want to apply gpfsprotocoldefaults then specify scale_cluster_profile_name: gpfsprotocoldefaults
scale_cluster_profile_name: None

# System-defined profiles are located in /usr/lpp/mmfs/profiles/
scale_cluster_profile_dir_path: /usr/lpp/mmfs/profiles/
```

UT Results:
```
Able to apply apply profile with Ansible now ,
[root@scale-52 ~]# mmlsconfig
Configuration data for cluster gpfs1.local:
-------------------------------------------
clusterName gpfs1.local
clusterId 13029570707536579647
autoload yes
profile gpfsProtocolDefaults
dmapiFileHandleSize 32
minReleaseLevel 5.0.5.0
ccrEnabled yes
cipherList AUTHONLY
maxblocksize 16M
[cesNodes]
maxMBpS 5000
numaMemoryInterleave yes
enforceFilesetQuotaOnRoot yes
workerThreads 512
[common]
adminMode centralFile systems in cluster gpfs1.local:
------------------------------------
(none)Without profile :
[root@scale-51 ~]# mmlsconfig
Configuration data for cluster gpfs1.local:
-------------------------------------------
clusterName gpfs1.local
clusterId 6993155638009106976
autoload no
dmapiFileHandleSize 32
minReleaseLevel 5.0.5.0
ccrEnabled yes
cipherList AUTHONLY
adminMode centralFile systems in cluster gpfs1.local:
-----------------------
```

I will be working to add this in the README. 

Author: Rajan Mishra <rajanmis@in.ibm.com>