### PR TITLE
Profile configuration support code for mmcrcluster into master

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -52,3 +52,13 @@ scale_storage_filesystem_defaults:
   ## for an existing NSD header (dangerous!)
   overwriteNSDs: false
 # defaults file for node
+
+# Specifies a predefined profile of attributes to be applied.
+# System-defined profiles are located in /usr/lpp/mmfs/profiles/. 
+# The following system-defined profile names are accepted: 
+# gpfsprotocoldefaults and gpfsprotocolrandomio
+# eg: If you want to apply gpfsprotocoldefaults then specify scale_cluster_profile_name: gpfsprotocoldefaults
+scale_cluster_profile_name: None
+
+# System-defined profiles are located in /usr/lpp/mmfs/profiles/
+scale_cluster_profile_dir_path: /usr/lpp/mmfs/profiles/

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -72,10 +72,31 @@
         src: NewNodeFile.j2
         dest: /var/tmp/NodeFile
 
-    - name: cluster | Create new cluster
-      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }}
-      notify: accept-licenses
+    - name: check | Stat GPFS profile file
+      find:
+        paths: "{{ scale_cluster_profile_dir_path }}"
+        patterns: "{{ scale_cluster_profile_name }}.profile"
+      register: stat_profile_result
 
+    - name: install | Initialize gpfs profile
+      set_fact:
+         profile_type: ""
+
+    - name: install | Set gpfs profile if it is defined
+      set_fact:
+         profile_type: "--profile {{ scale_cluster_profile_name }}"
+      when: 
+        - stat_profile_result.matched == 1
+        - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+
+    - name: cluster | Create new cluster
+      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }} {{ profile_type }}
+      notify: accept-licenses
+      register: mmcrcluster_results
+
+    - debug:
+         msg: "{{ mmcrcluster_results.cmd }}"
+     
     - name: cluster | Cleanup new cluster NodeFile
       file:
         path: /var/tmp/NodeFile


### PR DESCRIPTION
```
# Specifies a predefined profile of attributes to be applied.
# System-defined profiles are located in /usr/lpp/mmfs/profiles/. 
# The following system-defined profile names are accepted: 
# gpfsprotocoldefaults and gpfsprotocolrandomio
# eg: If you want to apply gpfsprotocoldefaults then specify scale_cluster_profile_name: gpfsprotocoldefaults
scale_cluster_profile_name: None

# System-defined profiles are located in /usr/lpp/mmfs/profiles/
scale_cluster_profile_dir_path: /usr/lpp/mmfs/profiles/
```

UT Results:
```
Able to apply apply profile with Ansible now ,
[root@scale-52 ~]# mmlsconfig
Configuration data for cluster gpfs1.local:
-------------------------------------------
clusterName gpfs1.local
clusterId 13029570707536579647
autoload yes
profile gpfsProtocolDefaults
dmapiFileHandleSize 32
minReleaseLevel 5.0.5.0
ccrEnabled yes
cipherList AUTHONLY
maxblocksize 16M
[cesNodes]
maxMBpS 5000
numaMemoryInterleave yes
enforceFilesetQuotaOnRoot yes
workerThreads 512
[common]
adminMode centralFile systems in cluster gpfs1.local:
------------------------------------
(none)Without profile :
[root@scale-51 ~]# mmlsconfig
Configuration data for cluster gpfs1.local:
-------------------------------------------
clusterName gpfs1.local
clusterId 6993155638009106976
autoload no
dmapiFileHandleSize 32
minReleaseLevel 5.0.5.0
ccrEnabled yes
cipherList AUTHONLY
adminMode centralFile systems in cluster gpfs1.local:
-----------------------
```

I will be working to add this in the README. 

Author: Rajan Mishra <rajanmis@in.ibm.com>