### PR TITLE
User defined profile support for mmcrcluster into dev

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -62,3 +62,9 @@ scale_cluster_profile_name: None
 
 # System-defined profiles are located in /usr/lpp/mmfs/profiles/
 scale_cluster_profile_dir_path: /usr/lpp/mmfs/profiles/
+
+gpfs_cluster_system_profile:
+   - gpfsprotocoldefaults
+   - gpfsprotocolrandomio
+
+scale_cluster_profile_system_path: /var/mmfs/etc/

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -63,6 +63,17 @@
   with_items: "{{ ansible_play_hosts }}"
   changed_when: false
 
+- name: check | Find GPFS user profile
+  find:
+    paths: "{{ scale_cluster_profile_dir_path }}"
+    patterns: "{{ scale_cluster_profile_name }}.profile"
+  register: stat_user_profile_result
+  run_once: true
+  delegate_to: localhost
+  when:
+    - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+    - scale_cluster_profile_name not in gpfs_cluster_system_profile
+
 #
 # Create new cluster
 #
@@ -78,6 +89,30 @@
         patterns: "{{ scale_cluster_profile_name }}.profile"
       register: stat_profile_result
 
+    - block:
+        - name: check | cluster profile name validation
+          assert:
+            that:
+              - scale_cluster_profile_name is not match("gpfs.*")
+            msg: >-
+              A user-defined profile must not begin with the string 'gpfs'
+
+        - name: check | cluster profile format validation
+          assert:
+            that:
+              - stat_user_profile_result.matched == 1
+            msg: >-
+              A user-defined profile must have the .profile suffix
+
+        - name: cluster | Copy user defined profile
+          copy:
+            src: "{{ stat_user_profile_result.files.0.path | basename }}"
+            dest: "{{ scale_cluster_profile_system_path }}"
+            mode: a+x
+      when:
+        - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+        - scale_cluster_profile_name not in gpfs_cluster_system_profile
+
     - name: install | Initialize gpfs profile
       set_fact:
          profile_type: ""
@@ -86,7 +121,7 @@
       set_fact:
          profile_type: "--profile {{ scale_cluster_profile_name }}"
       when: 
-        - stat_profile_result.matched == 1
+        - (stat_profile_result.matched) == 1 or (stat_user_profile_result is defined and stat_user_profile_result.matched == 1)
         - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
 
     - name: cluster | Create new cluster

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -71,7 +71,7 @@
   run_once: true
   delegate_to: localhost
   when:
-    - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+    - scale_cluster_profile_name is defined and scale_cluster_profile_name != 'None'
     - scale_cluster_profile_name not in gpfs_cluster_system_profile
 
 #

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -109,8 +109,8 @@
             src: "{{ stat_user_profile_result.files.0.path | basename }}"
             dest: "{{ scale_cluster_profile_system_path }}"
             mode: a+x
-      when:
-        - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+      when: 
+        - scale_cluster_profile_name is defined and scale_cluster_profile_name != 'None'
         - scale_cluster_profile_name not in gpfs_cluster_system_profile
 
     - name: install | Initialize gpfs profile
@@ -122,7 +122,7 @@
          profile_type: "--profile {{ scale_cluster_profile_name }}"
       when: 
         - (stat_profile_result.matched) == 1 or (stat_user_profile_result is defined and stat_user_profile_result.matched == 1)
-        - scale_cluster_profile_name is defined and scale_cluster_profile_name != None
+        - scale_cluster_profile_name is defined and scale_cluster_profile_name != 'None'
 
     - name: cluster | Create new cluster
       command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }} {{ profile_type }}


### PR DESCRIPTION
User defined profile support for mmcrcluster into dev

```
---
- hosts: cluster01
  vars:
    - scale_cluster_profile_dir_path: /opt/
    - scale_cluster_profile_name: sncprofile
```
Author: Rajan Mishra <rajanmis@in.ibm.com>