### PR TITLE
Data Access Edition issue fixed

### DIFF
--- a/roles/core/node/tasks/install_license_pkg.yml
+++ b/roles/core/node/tasks/install_license_pkg.yml
@@ -34,7 +34,7 @@
   
 - block:
     #
-    # Find GPFS adv packgae
+    # Find GPFS adv package
     #
     - name: install | Find GPFS Advance (gpfs.adv) RPM
       find:
@@ -43,7 +43,7 @@
       register: scale_install_gpfs_adv
 
     #
-    # Find GPFS crypto packgae
+    # Find GPFS crypto package
     #
     - name: install | Find GPFS crypto (gpfs.crypto) RPM
       find:

--- a/roles/core/node/tasks/install_license_pkg.yml
+++ b/roles/core/node/tasks/install_license_pkg.yml
@@ -32,26 +32,28 @@
   set_fact:
     scale_gpfs_license_rpm: "{{ gpfs_license_rpm }}"
   
-#
-# Find GPFS adv packgae
-#
-- name: install | Find GPFS Advance (gpfs.adv) RPM
-  find:
-    paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.adv*{{ scale_architecture }}*
-  register: scale_install_gpfs_adv
-  when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
+- block:
+    #
+    # Find GPFS adv packgae
+    #
+    - name: install | Find GPFS Advance (gpfs.adv) RPM
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.adv*{{ scale_architecture }}*
+      register: scale_install_gpfs_adv
 
+    #
+    # Find GPFS crypto packgae
+    #
+    - name: install | Find GPFS crypto (gpfs.crypto) RPM
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.crypto*{{ scale_architecture }}*
+      register: scale_install_gpfs_crypto
 
-#
-# Find GPFS crypto packgae
-#
-- name: install | Find GPFS crypto (gpfs.crypto) RPM
-  find:
-    paths: "{{ gpfs_path_url }}"
-    patterns: gpfs.crypto*{{ scale_architecture }}*
-  register: scale_install_gpfs_crypto
-  when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
+  when:
+    - '"gpfs.license.std" not in scale_gpfs_license_rpm'
+    - '"gpfs.license.da" not in scale_gpfs_license_rpm'
 
 
 #
@@ -77,4 +79,6 @@
   with_items:
     - "{{ scale_install_gpfs_adv.files.0.path | basename }}"
     - "{{ scale_install_gpfs_crypto.files.0.path | basename }}"
-  when: '"gpfs.license.std" not in scale_gpfs_license_rpm'
+  when:
+    - '"gpfs.license.std" not in scale_gpfs_license_rpm'
+    - '"gpfs.license.da" not in scale_gpfs_license_rpm'


### PR DESCRIPTION
```
[root@scale-52 ~]# mmlslicense

 Summary information 
---------------------
Number of nodes defined in the cluster:                          1
Number of nodes with server license designation:                 1
Number of nodes with FPO license designation:                    0
Number of nodes with client license designation:                 0
Number of nodes still requiring server license designation:      0
Number of nodes still requiring client license designation:      0
This node runs IBM Spectrum Scale Data Access Edition

```

```
[root@scale-51 ~]# mmlslicense

 Summary information 
---------------------
Number of nodes defined in the cluster:                          2
Number of nodes with server license designation:                 2
Number of nodes with FPO license designation:                    0
Number of nodes with client license designation:                 0
Number of nodes still requiring server license designation:      0
Number of nodes still requiring client license designation:      0
This node runs IBM Spectrum Scale Advanced Edition
```

```

[root@scale-54 ~]# mmlslicense

 Summary information 
---------------------
Number of nodes defined in the cluster:                          1
Number of nodes with server license designation:                 1
Number of nodes with FPO license designation:                    0
Number of nodes with client license designation:                 0
Number of nodes still requiring server license designation:      0
Number of nodes still requiring client license designation:      0
This node runs IBM Spectrum Scale Standard Edition
```