### PR TITLE
Allow for a variable to point to a config file for "mmcrcluster -c configFile"

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -71,3 +71,6 @@ gpfs_cluster_system_profile:
    - gpfsprotocolrandomio
 
 scale_cluster_profile_system_path: /var/mmfs/etc/
+
+# configuration file that can be passed to mmcrcluster [-c configFile]
+spectrumscale_config_file: ""

--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -116,6 +116,7 @@
     - name: install | Initialize gpfs profile
       set_fact:
          profile_type: ""
+         config_file_option: ""
 
     - name: install | Set gpfs profile if it is defined
       set_fact:
@@ -124,8 +125,18 @@
         - scale_cluster_profile_name is defined and scale_cluster_profile_name != 'None' 
         - (stat_profile_result.matched) == 1 or (stat_user_profile_result is defined and stat_user_profile_result.matched == 1)
 
+    - name: cluster | check if Spectrum Scale config file is present
+      stat:
+         path: "{{ spectrumscale_config_file }}"
+      register: configfile_result 
+
+    - name: cluster | set configfile when file exists
+      set_fact:
+          config_file_option: "-c {{ spectrumscale_config_file }}"
+      when: configfile_result.stat.exists
+
     - name: cluster | Create new cluster
-      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }} {{ profile_type }}
+      command: /usr/lpp/mmfs/bin/mmcrcluster -N /var/tmp/NodeFile -C {{ scale_cluster_clustername }} {{ config_file_option }} {{ profile_type }}
       notify: accept-licenses
       register: mmcrcluster_results
 


### PR DESCRIPTION
Resolves #180 

This runs a stat on the variable `spectrumscale_config_file` and if defined, it will pass the file along to `mmcrcluster` using the `-c configFile` option. 

In my playbook.yaml, I've added this variable: 

```
  vars:
    - spectrumscale_config_file: /root/mmfs.cfg
```

This file contains the following config: 
```
# cat /root/mmfs.cfg
workersThreads 2048
```

Then running the playbook, we see the following output: 
```

2020-07-07 19:58:24,170 p=4471 u=root n=ansible | TASK [ibm_spectrum_scale.install_infra.core/cluster : cluster | Create new cluster] ***
2020-07-07 19:58:38,495 p=4471 u=root n=ansible | changed: [configfile-x-master -> configfile-x-master]
2020-07-07 19:58:38,590 p=4471 u=root n=ansible | TASK [ibm_spectrum_scale.install_infra.core/cluster : debug] *******************
2020-07-07 19:58:38,664 p=4471 u=root n=ansible | ok: [configfile-x-master -> configfile-x-master] => {
    "msg": [
        "/usr/lpp/mmfs/bin/mmcrcluster",
        "-N",
        "/var/tmp/NodeFile",
        "-C",
        "configfile-x",
        "-c",
        "/root/mmfs.cfg"
    ]
}
```


After complete: 
```
[root@configfile-x-master ~]# mmlsconfig | grep Threa
workersThreads 2048
```