### PR TITLE
Copy file from remote_source and use the stat_profile_result

### DIFF
--- a/roles/core/cluster/tasks/cluster.yml
+++ b/roles/core/cluster/tasks/cluster.yml
@@ -100,18 +100,21 @@
         - name: check | cluster profile format validation
           assert:
             that:
-              - stat_user_profile_result.matched == 1
+              - stat_profile_result.matched == 1
             msg: >-
               A user-defined profile must have the .profile suffix
 
         - name: cluster | Copy user defined profile
           copy:
-            src: "{{ stat_user_profile_result.files.0.path }}"
+            src: "{{ stat_profile_result.files.0.path }}"
             dest: "{{ scale_cluster_profile_system_path }}"
             mode: a+x
+            # scale-core, the files are already on the pod, running from operator
+            remote_src: true
       when: 
         - scale_cluster_profile_name is defined and scale_cluster_profile_name != 'None'
         - scale_cluster_profile_name not in gpfs_cluster_system_profile
+        - stat_profile_result.matched > 0
 
     - name: install | Initialize gpfs profile
       set_fact:


### PR DESCRIPTION
Signed-off-by: Victor Hu <whowutwut@gmail.com>

Resolves #183 

In my environment, the node that's running the ansible-playbook is NOT part of the spectrum scale cluster.  The `/var/mmfs/etc/scalecore.profile` is generated by template onto all the nodes in the scale cluster.   So I added the remote_src: true 

I don't expect this to be merged since this will probably impact other deployments, but I wanted to ask @rajan-mis  why we store a stat result in `stat_profile_result` but we never use it. 