### PR TITLE
[core] Fix upgrade for repo install method

### DIFF
--- a/roles/core/node/tasks/upgrade.yml
+++ b/roles/core/node/tasks/upgrade.yml
@@ -20,6 +20,7 @@
   args:
     warn: false
   register: scale_repo_gpfsversion
+  when: scale_install_repository_url is undefined
   changed_when: false
 
 - name: update | Check if node needs to be updated


### PR DESCRIPTION
The variable `gpfs_path_url` is only defined for the local & remote installation package method (in `install.yml`). However, it is used for all install methods (in `upgrade.yml`). Fix is to not query packages for repo install method.