### PR TITLE
Fix for node expansion is not configuring pmsesnors and not starting pmsensors service. Signed-off-by: Rajan Mishra rajanmis@in.ibm.com

### DIFF
--- a/roles/zimon/cluster/tasks/configure.yml
+++ b/roles/zimon/cluster/tasks/configure.yml
@@ -2,12 +2,12 @@
 # Configure GUI service and performance collection
 
 # Make default variables available in hostvars
-- name: cluster | Set default zimon collector role
+- name: configure | Set default zimon collector role
   set_fact:
     scale_zimon_collector: "{{ scale_zimon_collector }}"
   when: hostvars[inventory_hostname].scale_zimon_collector is undefined
 
-- name: cluster | Set default zimon collector role if GUI node is defined
+- name: configure | Set default zimon collector role if GUI node is defined
   set_fact:
     scale_zimon_collector: "{{ scale_cluster_gui }}"
   when: (scale_cluster_gui is defined and scale_cluster_gui | bool)
@@ -25,7 +25,7 @@
   with_items: "{{ ansible_play_hosts }}"
   changed_when: false
 
-- name: cluster | check if zimon is enabled
+- name: configure | check if zimon is enabled
   set_fact:
     scale_cluster_zimon: true
   when:

--- a/roles/zimon/cluster/tasks/configure.yml
+++ b/roles/zimon/cluster/tasks/configure.yml
@@ -96,6 +96,12 @@
     msg: "{{ scale_zimon_conf_perfmon_check.stdout }}"
     verbosity: 2
 
+- name: configure | Check if initialize performance collection is already configured.
+  shell: "/usr/lpp/mmfs/bin/mmperfmon config show | grep colCandidates"
+  register: scale_zimon_conf_collector_check
+  failed_when: false
+  changed_when: false
+
 - name: configure | Enable nodes for performance collection #TODO discuss: should it be dependent on scale_zimon_collector?
   vars:
     sensor_nodes: "{{ ansible_play_hosts | list }}"
@@ -107,8 +113,7 @@
   ignore_errors: yes
   failed_when: "scale_zimon_conf_enable_node_perfmon.rc != 0 and 'Propagating the cluster configuration data to all affected nodes.' not in scale_zimon_conf_enable_node_perfmon.stdout"
   when:
-    - scale_cluster_zimon | bool
-    - " 'perfmon' not in scale_zimon_conf_perfmon_check.stdout"
+    - " 'colCandidates =' in scale_zimon_conf_collector_check.stdout"
 
 #
 # Start and enable PMCollector and PM Sensors.
@@ -126,5 +131,6 @@
     name: pmsensors
     state: started
     enabled: true
-  when: scale_zimon_collector | bool
+  when:
+    - " 'colCandidates =' in scale_zimon_conf_collector_check.stdout"
   #TODO check: don't know what to check if the init is already run


### PR DESCRIPTION
Signed-off-by: Rajan Mishra rajanmis@in.ibm.com

Fix for node expansion is not configuring pmsesnors and not starting pmsensors service.

**perfmon designation :**
```
[root@test-vm4 ibm-spectrum-scale-install-infra]# mmlscluster

GPFS cluster information
========================
  GPFS cluster name:         gpfs1.local
  GPFS cluster id:           7179322150813988524
  GPFS UID domain:           gpfs1.local
  Remote shell command:      /usr/bin/ssh
  Remote file copy command:  /usr/bin/scp
  Repository type:           CCR

GPFS cluster configuration servers:
-----------------------------------
  Primary server:    test-vm4  (not in use)
  Secondary server:  (none)

 Node  Daemon node name                    IP address   Admin node name                     Designation
--------------------------------------------------------------------------------------------------------
   2   test-vm4                                         192.168.100.101  test-vm4                          quorum-perfmon
   3   test-vm2                                         192.168.100.102 test-vm2                           quorum-perfmon
```

**pmsensors service:** 

```
[root@test-vm4 ibm-spectrum-scale-install-infra]# mmdsh -N all "systemctl status pmsensors | grep "Active:""
test-vm4:     Active: active (running) since Sat 2020-09-12 00:55:45 MST; 1h 19min ago
test-vm2:     Active: active (running) since Sat 2020-09-12 01:05:17 MST; 1h 9min ago
```

