### PR TITLE
Initial GPFS file audit logging installation and configuration support code

### DIFF
--- a/roles/scale_fileauditlogging/cluster/defaults/main.yml
+++ b/roles/scale_fileauditlogging/cluster/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) (audit logging) role -
+# either edit this file or define your own variables to override the defaults
+
+## Flag to enable fileauditlogging
+scale_fileauditlogging_enable: true
+
+## Default filesystem parameters for file audit logging-
+## can be overridden for each filesystem individually
+scale_storage_fal_defaults:
+  logfileset: .audit_log
+  retention: 365
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv

--- a/roles/scale_fileauditlogging/cluster/handlers/main.yml
+++ b/roles/scale_fileauditlogging/cluster/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for configure

--- a/roles/scale_fileauditlogging/cluster/meta/main.yml
+++ b/roles/scale_fileauditlogging/cluster/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  role_name: fileauditlogging
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) fileauditlogging
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies: []

--- a/roles/scale_fileauditlogging/cluster/tasks/configure.yml
+++ b/roles/scale_fileauditlogging/cluster/tasks/configure.yml
@@ -1,0 +1,38 @@
+---
+- block:  ## run_once: true
+    - name: configure | Consolidate defined filesystems
+      set_fact:
+        scale_storage_fsdefs:
+          "{{ ansible_play_hosts | map('extract', hostvars, 'scale_storage') | sum(start=[]) | map(attribute='filesystem') | list | unique }}"
+
+    - name: configure | Consolidate defined filesystem parameters for file audit logging
+      set_fact:
+        scale_storage_fsparams:
+          "{{ scale_storage_fsparams | default({}) | combine({ item.filesystem:item }, recursive=true) }}"
+      with_items: "{{ ansible_play_hosts | map('extract', hostvars, 'scale_storage') | sum(start=[]) }}"
+
+
+    - name: configure | Find created filesystem(s)
+      shell:
+       cmd: "/usr/lpp/mmfs/bin/mmlsfs all -Y | grep -v HEADER | cut -d ':' -f 7 | uniq"
+      register: scale_storage_filesystem
+      changed_when: false
+      failed_when: false
+
+    - name: configure | configure file audit logging
+      vars:
+        scale_fal_localspace_force: "{{ '--skip-local-space-check' if scale_fal_skip_localspace is defined else '' }}"
+      command:
+        /usr/lpp/mmfs/bin/mmaudit {{ item }} enable
+        --log-fileset {{ scale_storage_fsparams[item].logfileset | default(scale_storage_fal_defaults.logfileset) }}
+        --retention {{ scale_storage_fsparams[item].retention | default(scale_storage_fal_defaults.retention) }}
+        {{ scale_fal_localspace_force }}
+      register: scale_audit_command
+      when:
+        - scale_storage_fsdefs | length >= 1
+        - (scale_storage_fsparams[item].scale_fal_enable is defined) and (scale_storage_fsparams[item].scale_fal_enable | bool)
+      with_items: "{{ scale_storage_fsdefs }}"
+
+    - debug:
+        msg: "{{ scale_audit_command.results }}"
+  run_once: true

--- a/roles/scale_fileauditlogging/cluster/tasks/main.yml
+++ b/roles/scale_fileauditlogging/cluster/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for configure
+- import_tasks: configure.yml
+  tags: configure
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/cluster/tests/inventory
+++ b/roles/scale_fileauditlogging/cluster/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_fileauditlogging/cluster/tests/test.yml
+++ b/roles/scale_fileauditlogging/cluster/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - configure

--- a/roles/scale_fileauditlogging/cluster/vars/main.yml
+++ b/roles/scale_fileauditlogging/cluster/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (File audit logging) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/scale_fileauditlogging/node/defaults/main.yml
+++ b/roles/scale_fileauditlogging/node/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) (audit logging) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale file audit logging repository
+## (copy the contents of /usr/lpp/mmfs/.../gpfs_rpms/rhel7 to build your repository)
+# scale_install_fileauditlogging_repository_url: http://infraserv/gpfs_rpms/
+
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## List of packages to install for file audit logging
+scale_auditlogging_packages:
+  - gpfs.librdkafka*{{ scale_architecture }}
+
+## Flag to enable fileauditlogging
+scale_fileauditlogging_enable: true
+
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv

--- a/roles/scale_fileauditlogging/node/handlers/main.yml
+++ b/roles/scale_fileauditlogging/node/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for install

--- a/roles/scale_fileauditlogging/node/meta/main.yml
+++ b/roles/scale_fileauditlogging/node/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: fileauditlogging
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) fileauditlogging
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+  - core/common

--- a/roles/scale_fileauditlogging/node/tasks/apt/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/apt/install.yml
@@ -1,0 +1,19 @@
+---
+
+#
+# Install or update RPMs
+#
+- name: install | Install GPFS Zimon packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: present
+  when: scale_install_fileauditlogging_repository_url is defined
+
+- block:
+    - name: install | Install GPFS file audit logging packages
+      apt:
+        deb: "{{ item }}"
+        state: present
+      with_items:
+        - "{{ scale_install_all_packages }}"
+  when: scale_install_fileauditlogging_repository_url is not defined

--- a/roles/scale_fileauditlogging/node/tasks/apt/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/apt/install.yml
@@ -3,7 +3,7 @@
 #
 # Install or update RPMs
 #
-- name: install | Install GPFS Zimon packages
+- name: install | Install GPFS file audit logging packages
   package:
     name: "{{ scale_install_all_packages }}"
     state: present

--- a/roles/scale_fileauditlogging/node/tasks/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install.yml
@@ -1,0 +1,66 @@
+---
+# Install or update RPMs
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - name: install | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_fileauditlogging_repository_url is defined
+        - scale_install_localpkg_path is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+
+    - name: install | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_fileauditlogging_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: install | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_fileauditlogging_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: install | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of RPMs
+#
+- name: install | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- meta: flush_handlers
+
+#
+# Install or update RPMs
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/scale_fileauditlogging/node/tasks/install_dir_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_dir_pkg.yml
@@ -67,7 +67,7 @@
           No GPFS auditlogin librakafka(gpfs.librdkafka) package found
           {{ gpfs_path_url }}gpfs.librdkafka*.rpm
 
-    - name: install | Add GPFS zimon collector packages to list
+    - name: install | Add GPFS file audit logging packages to list
       vars:
         current_package: "{{ gpfs_path_url }}/{{ item }}"
       set_fact:

--- a/roles/scale_fileauditlogging/node/tasks/install_dir_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_dir_pkg.yml
@@ -1,0 +1,78 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: install | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: install | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: install | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: install | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.librdkafka*.rpm
+      register: scale_install_gpfs_fal
+
+    - name: install | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ gpfs_path_url }}gpfs.librdkafka*.rpm
+
+    - name: install | Add GPFS zimon collector packages to list
+      vars:
+        current_package: "{{ gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/node/tasks/install_local_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_local_pkg.yml
@@ -1,0 +1,141 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: install | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+      register: scale_install_localpkg
+
+    - name: install | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: install | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: install | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: install | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: install | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: install | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: install | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: install | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: install | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: install | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: install | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: install | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_fal_url }}"
+        patterns: gpfs.librdkafka*.rpm
+      register: scale_install_gpfs_fal
+
+    - name: install | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ scale_extracted_path }}/{{ scale_fal_url }}gpfs.librdkafka*.rpm
+
+    - name: install | Add GPFS file audit logging packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_fal_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/node/tasks/install_remote_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_remote_pkg.yml
@@ -1,0 +1,129 @@
+
+---
+
+# Remote package installation method
+
+- name: install | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+  register: scale_install_remotepkg
+
+
+- name: install | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+
+
+# Optionally, verify package checksum
+
+
+- name: install | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: install | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: install | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+
+
+# Extract installation package
+
+
+
+- name: install | Stat extracted packages
+  stat:
+    path: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+  register: scale_install_gpfs_rpmdir
+
+
+- name: install | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+
+- name: install | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+
+
+- name: install | Stat extracted packages
+  stat:
+    path: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+  register: scale_install_gpfs_rpmdir
+
+
+- name: install | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: install | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_fal_url }}"
+        patterns: gpfs.librdkafka*.rpm
+      register: scale_install_gpfs_fal
+
+    - name: install | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ scale_extracted_path }}/{{ scale_fal_url }}gpfs.librdkafka*.rpm
+
+    - name: install | Add GPFS file audit logging packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_fal_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/node/tasks/install_repository.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_repository.yml
@@ -61,7 +61,7 @@
 - name: install | Configure fal repository
   zypper_repository:
     name: spectrum-scale-fal-sles
-    description: IBM Spectrum Scale (ZIMon)
+    description: IBM Spectrum Scale (FAL)
     repo: "{{ scale_install_fileauditlogging_repository_url }}{{ scale_fal_url }}"
     disable_gpg_check: no
     state: present

--- a/roles/scale_fileauditlogging/node/tasks/install_repository.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_repository.yml
@@ -1,0 +1,79 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: install | Initialize
+  set_fact:
+   scale_fal_url: ""
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: install | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: install | Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: install | Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: install | Configure fal YUM repository
+  yum_repository:
+    name: spectrum-scale-fal
+    description: IBM Spectrum Scale (FAL)
+    baseurl: "{{ scale_install_fileauditlogging_repository_url }}{{ scale_fal_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_fileauditlogging_repository_url != 'existing'
+
+- name: install | Configure fal APT repository
+  apt_repository:
+    filename: spectrum-scale-fal-debs
+    repo: "deb [trusted=yes] {{ scale_install_fileauditlogging_repository_url }}{{ scale_fal_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (FAL debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_fileauditlogging_repository_url != 'existing'
+
+- name: install | Configure fal repository
+  zypper_repository:
+    name: spectrum-scale-fal-sles
+    description: IBM Spectrum Scale (ZIMon)
+    repo: "{{ scale_install_fileauditlogging_repository_url }}{{ scale_fal_url }}"
+    disable_gpg_check: no
+    state: present
+  when:
+    - ansible_pkg_mgr == 'zypper'
+
+#
+# Add FAL packages
+#
+- name: install | Add GPFS file audit logging packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_auditlogging_packages }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/node/tasks/main.yml
+++ b/roles/scale_fileauditlogging/node/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for install
+- import_tasks: install.yml
+  tags: install
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/node/tasks/yum/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/yum/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update RPMs
+#
+- name: Initialize
+  set_fact:
+    disable_gpgcheck: "no"
+
+- name: Disable gpg check
+  set_fact:
+    disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: install | Install GPFS file audit logging packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: present
+    disable_gpg_check: "{{ disable_gpgcheck }}"

--- a/roles/scale_fileauditlogging/node/tasks/zypper/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/zypper/install.yml
@@ -1,0 +1,7 @@
+---
+- block:
+    - name: install | Install GPFS file audit logging packages
+      zypper:
+          name: "{{ scale_install_all_packages }}"
+          state: present
+          disable_gpg_check: no

--- a/roles/scale_fileauditlogging/node/tests/inventory
+++ b/roles/scale_fileauditlogging/node/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_fileauditlogging/node/tests/test.yml
+++ b/roles/scale_fileauditlogging/node/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - install

--- a/roles/scale_fileauditlogging/node/vars/main.yml
+++ b/roles/scale_fileauditlogging/node/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (File audit logging) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/scale_fileauditlogging/postcheck/defaults/main.yml
+++ b/roles/scale_fileauditlogging/postcheck/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for postcheck

--- a/roles/scale_fileauditlogging/postcheck/handlers/main.yml
+++ b/roles/scale_fileauditlogging/postcheck/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for postcheck

--- a/roles/scale_fileauditlogging/postcheck/meta/main.yml
+++ b/roles/scale_fileauditlogging/postcheck/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  role_name: fileauditlogging
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) fileauditlogging
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies: []

--- a/roles/scale_fileauditlogging/postcheck/tasks/check.yml
+++ b/roles/scale_fileauditlogging/postcheck/tasks/check.yml
@@ -1,0 +1,13 @@
+---
+- block:
+   - name: check | File Audit Logging Status
+     shell:
+      cmd: "/usr/lpp/mmfs/bin/mmaudit all list -Y"
+     register: scale_auditlogging_status
+     ignore_errors: true
+
+   - name: check | File Audit Logging Running Status
+     debug:
+       msg: "{{ scale_auditlogging_status.stdout }}"
+
+  run_once: true

--- a/roles/scale_fileauditlogging/postcheck/tasks/main.yml
+++ b/roles/scale_fileauditlogging/postcheck/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for postcheck
+- include_tasks: check.yml
+  tags: always
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/postcheck/tests/inventory
+++ b/roles/scale_fileauditlogging/postcheck/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_fileauditlogging/postcheck/tests/test.yml
+++ b/roles/scale_fileauditlogging/postcheck/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - postcheck

--- a/roles/scale_fileauditlogging/postcheck/vars/main.yml
+++ b/roles/scale_fileauditlogging/postcheck/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for postcheck

--- a/roles/scale_fileauditlogging/precheck/defaults/main.yml
+++ b/roles/scale_fileauditlogging/precheck/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for precheck

--- a/roles/scale_fileauditlogging/precheck/handlers/main.yml
+++ b/roles/scale_fileauditlogging/precheck/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for precheck

--- a/roles/scale_fileauditlogging/precheck/meta/main.yml
+++ b/roles/scale_fileauditlogging/precheck/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  role_name: fileauditlogging
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) fileauditlogging
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies: []

--- a/roles/scale_fileauditlogging/precheck/tasks/main.yml
+++ b/roles/scale_fileauditlogging/precheck/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for precheck

--- a/roles/scale_fileauditlogging/precheck/tests/inventory
+++ b/roles/scale_fileauditlogging/precheck/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_fileauditlogging/precheck/tests/test.yml
+++ b/roles/scale_fileauditlogging/precheck/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - precheck

--- a/roles/scale_fileauditlogging/precheck/vars/main.yml
+++ b/roles/scale_fileauditlogging/precheck/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for precheck


### PR DESCRIPTION
Signed-off-by: Rajan Mishra rajanmis@in.ibm.com

This ansible role performs following tasks:


-   install the packages required  i.e gpfs.librdkafka by GPFS file audit logging  component. 

-    Ensure all the prerequisites required to configure GPFS file audit logging are satisfied then enable the fileaudit 
      logging configuration based on user  specified inventory for file audit logging.  

Inventory example:

Required flag to enable fal:
`"scale_fal_enable": true`

```
"scale_storage":[
    {
      "filesystem": "fs1",
      "blockSize": 4M,
      "defaultDataReplicas": 1,
      "defaultMountPoint": "/mnt/fs1",
      "scale_fal_enable": true
      "disks": [
       {
        "device": "/dev/sdd",
        "nsd": "nsd1",
        "servers": "host-vm1"
       },
       {
        "device": "/dev/sdf",
        "nsd": "nsd2",
        "servers": "host-vm1,host-vm2"
       }
      ]
    }
  ] 
```

Other option argument :
```
"logfileset": .audit_log
"retention": 365
```