### PR TITLE
Set "automaticMountOption": true by default for filesystem

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -48,7 +48,7 @@ scale_storage_filesystem_defaults:
   defaultMetadataReplicas: 1
   defaultDataReplicas: 1
   numNodes: 32
-  automaticMountOption: false
+  automaticMountOption: true
   ## defaultMountPoint will be this prefix, followed by the filesystem name
   defaultMountPoint_prefix: /mnt/
   ## Overwrite existing NSDs - if set to 'true' then disks will *not* be checked


### PR DESCRIPTION
Signed-off-by: Rajan Mishra rajanmis@in.ibm.com

Set "automaticMountOption": true by default for filesystem

@mrolyat  FYI.
```
 -  automaticMountOption: false
 +  automaticMountOption: true
```