### PR TITLE
IBM Spectrum Scale Erasure Code Edition configuration role

### DIFF
--- a/roles/scale_ece/cluster/defaults/main.yml
+++ b/roles/scale_ece/cluster/defaults/main.yml
@@ -1,0 +1,63 @@
+---
+# Default variables for the IBM Spectrum Scale (ECE) (Erasure Code Edition) role -
+# either edit this file or define your own variables to override the defaults
+
+## Default ECE parameters for mmvdisk-
+## can be overridden for each filesystem individually
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv
+
+# Example to define json inventory for Erasure Code Edition
+# recovery group, vdisk sets and filesystem
+# "scale_ece_rg":[
+#     {
+#       "rg": [
+#        {
+#         "rg": "rg_1",
+#         "nodeclass": "nc_1",
+#         "servers": "scale_out_vm1,scale_out_vm2,scale_out_vm3,scale_out_vm4"
+#        },
+#        {
+#         "rg": "rg_2",
+#         "nodeclass": "nc_2",
+#         "servers": "scale_out_vm5,scale_out_vm6,scale_out_vm7,scale_out_vm8"
+#        }
+#       ]
+#     }
+# ],
+# "scale_ece_vdisk":[
+#  {
+#       "vs": [
+#        {
+#         "rg": "rg_1",
+#         "vdisk": "vs_1",
+#         "ec": "4+3P",
+#         "blocksize": "4M",
+#         "Size": "50"
+#        },
+#        {
+#         "rg": "rg_2",
+#         "vdisk": "vs_2",
+#         "ec": "4+3P",
+#         "blocksize": "4M",
+#         "Size": "50"
+#        }
+#       ]
+#     }
+# ],
+# "scale_ece_filesystem":[
+#  {
+#       "fs": [
+#        {
+#         "filesystem": "fs_1",
+#         "vs": "vs_1",
+#         "mount_point": "/gpfs"
+#        },
+#        {
+#         "filesystem": "fs_2",
+#         "vs": "vs_2",
+#         "mount_point": "/gpfs"
+#        }
+#       ]
+#     }
+# ]

--- a/roles/scale_ece/cluster/handlers/main.yml
+++ b/roles/scale_ece/cluster/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for configure

--- a/roles/scale_ece/cluster/meta/main.yml
+++ b/roles/scale_ece/cluster/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  role_name: scale_ece
+  author: IBM Corporation
+  description: Role for configuring IBM Spectrum Scale (GPFS) Erasure Code Edition configuration role
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies: []

--- a/roles/scale_ece/cluster/tasks/create_filesystem.yml
+++ b/roles/scale_ece/cluster/tasks/create_filesystem.yml
@@ -1,0 +1,34 @@
+---
+- block:
+    - name: create | Create filesystem
+      command: "{{ scale_command_path }}mmvdisk fs create --fs {{ item.1.filesystem }} --vs {{ item.1.vs }} --mmcrfs -T {{ item.1.mount_point }}/{{ item.1.filesystem }}"
+      register: scale_fs_create
+      failed_when: scale_fs_create.rc != 0
+      when:
+        - item.1.filesystem is defined
+        - item.1.vs
+        - item.1.mount_point
+
+    - name: create | Waiting for node become active
+      shell: "{{ scale_command_path }}mmgetstate -Y | grep active"
+      register: scale_gpfs_state
+      until: scale_gpfs_state.rc == 0
+      retries: 5
+      delay: 30
+      ignore_errors: True
+
+    - name: create | Mount filesystem
+      command: "{{ scale_command_path }}mmmount {{ item.1.filesystem }} -a"
+      register: scale_fs_mount
+      failed_when: scale_fs_mount.rc != 0
+      when:
+        - item.1.filesystem is defined
+
+    - name: create | End of filesystem creation
+      debug:
+        msg: filesystem {{ item.1.filesystem }} was successfully created.
+      when:
+        - item.1.filesystem is defined
+  rescue:
+    - debug:
+        msg: "I caught an error, Please take a look to the output given and refer to the Knowledge center!."

--- a/roles/scale_ece/cluster/tasks/create_recoverygroup.yml
+++ b/roles/scale_ece/cluster/tasks/create_recoverygroup.yml
@@ -1,0 +1,54 @@
+---
+- block:
+   - name: create | Find defined RGs
+     set_fact:
+       scale_rg_nodeclass:
+         "{{ scale_rg_nodeclass | default([]) + [ item.1.nodeclass | default('nc_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) ] }}"
+       scale_recoverygroup:
+         "{{ scale_recoverygroup | default([]) + [ item.1.rg | default('rg_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) ] }}"
+       scale_nc_servers:
+         "{{ scale_nc_servers | default([]) + [ item.1.servers ] }}"
+     when:
+       - item.1.servers is defined
+
+   - name: create | Create Node Class
+     vars:
+       current_nc: "{{ item.1.nodeclass | default('nc_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) }}"
+       current_nc_servers: "{{ item.1.servers }}"
+     command: "{{ scale_command_path }}mmvdisk nc create --node-class {{ current_nc }} -N {{ current_nc_servers }}"
+     register: scale_nc_create
+     failed_when: scale_nc_create.rc != 0
+     when:
+       - item.1.servers is defined
+
+
+   - name: create | Server configuration in process
+     debug:
+        msg: Configuring servers for filesystem creation. This may take a while. Please be patient.
+     run_once: true
+
+   - name: create | Configure Server
+     vars:
+       current_nc: "{{ item.1.nodeclass | default('nc_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) }}"
+     command: "{{ scale_command_path }}mmvdisk server configure --nc {{ current_nc }} --recycle one"
+     register: scale_serv_configure
+     failed_when: scale_serv_configure.rc != 0
+
+   - name: create | Waiting for node become active
+     shell: "{{ scale_command_path }}mmgetstate -Y | grep active"
+     register: scale_gpfs_state
+     until: scale_gpfs_state.rc == 0
+     retries: 5
+     delay: 30
+     ignore_errors: True
+
+   - name: create | Create Recovery Group
+     vars:
+       current_rg: "{{ item.1.rg | default('rg_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) }}"
+       current_nc: "{{ item.1.nodeclass | default('nc_' + (item.1.servers.split(',')[0] | regex_replace('\\W', '_')) | basename) }}"
+     command: "{{ scale_command_path }}mmvdisk rg create --rg {{ current_rg }} --nc {{ current_nc }}"
+     register: scale_rg_create
+     failed_when: scale_rg_create.rc != 0
+  rescue:
+   - debug:
+        msg: "I caught an error, Please take a look to the output given and refer to the Knowledge center!"

--- a/roles/scale_ece/cluster/tasks/create_vdisk.yml
+++ b/roles/scale_ece/cluster/tasks/create_vdisk.yml
@@ -1,0 +1,34 @@
+---
+- block:
+      - name: create | Define Vdiskset
+        vars:
+          current_vs: "{{ item.1.vdisk | default('vs_' + (item.1.rg | regex_replace('\\W', '_')) | basename) }}"
+          current_rg: "{{ item.1.rg }}"
+          current_code: "{{ item.1.ec }}"
+          current_bs: "{{ item.1.blocksize }}"
+          current_size: "{{ item.1.Size }}"
+        command: "{{ scale_command_path }}mmvdisk vs define --vs {{ current_vs }} --rg {{ current_rg }} --code {{ current_code }} --bs {{ current_bs }} --ss {{ current_size }}"
+        register: scale_vs_define
+        failed_when: scale_vs_define.rc != 0
+        when:
+          - item.1.vdisk is defined
+          - item.1.rg is defined
+          - item.1.ec is defined
+          - item.1.blocksize is defined
+          - item.1.Size is defined
+
+      - name: create | Create Vdiskset
+        vars:
+          current_vs: "{{ item.1.vdisk | default('vs_' + (item.1.rg | regex_replace('\\W', '_')) | basename) }}"
+        command: "{{ scale_command_path }}mmvdisk vs create --vs {{ current_vs }}"
+        register: scale_vs_create
+        failed_when: scale_vs_create.rc != 0
+        when:
+          - item.1.vdisk is defined
+
+      - name: create | Add vdisks to desire filesystem
+        debug:
+          msg: Vdisks created, add them to your filesystem using mmadddisk
+  rescue:
+    - debug:
+        msg: "I caught an error, Please take a look to the output given and refer to the Knowledge center!"

--- a/roles/scale_ece/cluster/tasks/main.yml
+++ b/roles/scale_ece/cluster/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# tasks file for configure
+- include_tasks: create_recoverygroup.yml
+  tags: configure
+  when:
+    - scale_ece_rg is defined
+  with_subelements:
+    - "{{ scale_ece_rg }}"
+    - rg
+  run_once: true
+
+- include_tasks: create_vdisk.yml
+  tags: configure
+  when:
+    - scale_ece_vdisk is defined
+  with_subelements:
+    - "{{ scale_ece_vdisk }}"
+    - vs
+  run_once: true
+
+- include_tasks: create_filesystem.yml
+  tags: configure
+  when:
+    - scale_ece_filesystem is defined
+  with_subelements:
+    - "{{ scale_ece_filesystem }}"
+    - fs
+  run_once: true

--- a/roles/scale_ece/cluster/tests/inventory
+++ b/roles/scale_ece/cluster/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_ece/cluster/tests/test.yml
+++ b/roles/scale_ece/cluster/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - configure

--- a/roles/scale_ece/cluster/vars/main.yml
+++ b/roles/scale_ece/cluster/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# Variables for the IBM Spectrum Scale (File audit logging) role -
+# Variables for the IBM Spectrum Scale (ECE) (Erasure Code Edition) role -
 # these variables are *not* meant to be overridden
 
 # default mm command exection path

--- a/roles/scale_ece/cluster/vars/main.yml
+++ b/roles/scale_ece/cluster/vars/main.yml
@@ -1,0 +1,6 @@
+---
+# Variables for the IBM Spectrum Scale (File audit logging) role -
+# these variables are *not* meant to be overridden
+
+# default mm command exection path
+scale_command_path: /usr/lpp/mmfs/bin/


### PR DESCRIPTION
IBM Spectrum Scale Erasure Code Edition configuration role

# Example to define json inventory for Erasure Code Edition
# recovery group, vdisk sets and filesystem
```
"scale_ece_rg":[
    {
      "rg": [
       {
        "rg": "rg_1",
        "nodeclass": "nc_1",
        "servers": "scale_out_vm1,scale_out_vm2,scale_out_vm3,scale_out_vm4"
       },
       {
        "rg": "rg_2",
        "nodeclass": "nc_2",
        "servers": "scale_out_vm5,scale_out_vm6,scale_out_vm7,scale_out_vm8"
       }
      ]
    }
],
"scale_ece_vdisk":[
 {
      "vs": [
       {
        "rg": "rg_1",
        "vdisk": "vs_1",
        "ec": "4+3P",
        "blocksize": "4M",
        "Size": "50"
       },
       {
        "rg": "rg_2",
        "vdisk": "vs_2",
        "ec": "4+3P",
        "blocksize": "4M",
        "Size": "50"
       }
      ]
    }
],
"scale_ece_filesystem":[
 {
      "fs": [
       {
        "filesystem": "fs_1",
        "vs": "vs_1",
        "mount_point": "/gpfs"
       },
       {
        "filesystem": "fs_2",
        "vs": "vs_2",
        "mount_point": "/gpfs"
       }
      ]
    }
]
```

Signed-off-by: Rajan Mishra rajanmis@in.ibm.com