### PR TITLE
GPFS startup fix for cloud expanision requirement for maintenance node

### DIFF
--- a/roles/core/cluster/tasks/cluster_start.yml
+++ b/roles/core/cluster/tasks/cluster_start.yml
@@ -13,6 +13,7 @@
   set_fact:
    scale_daemon_node_list: "{{ scale_daemon_node_list + [hostvars[item].scale_daemon_nodename] }}"
   when:
+    - hostvars[item].state is defined and hostvars[item].state != 'maintenance'
     - hostvars[item].scale_daemon_nodename is defined
     - not hostvars[item].scale_daemon_running
   with_items:


### PR DESCRIPTION
GPFS startup fix for cloud expanision requirement for maintenance node
Added implementation for` state="maintenance"`

Now  playbook will not try to startup gpfs is `state="maintenance"`

Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>