### PR TITLE
  Implementation of gpfs daemon network to ansible toolkit

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -25,6 +25,9 @@
 ## Spectrum Scale daemon nodename (defaults to node's hostname)
 scale_daemon_nodename: "{{ ansible_hostname }}"
 
+## Spectrum Scale admin nodename (defaults to node's hostname)
+scale_admin_nodename: "{{ ansible_hostname }}"
+
 ## Default cluster name
 scale_cluster_clustername: gpfs1.local
 

--- a/roles/core/cluster/tasks/check.yml
+++ b/roles/core/cluster/tasks/check.yml
@@ -17,6 +17,11 @@
     scale_daemon_nodename: "{{ scale_daemon_nodename }}"
   when: hostvars[inventory_hostname].scale_daemon_nodename is undefined
 
+- name: check | Set default admin nodename
+  set_fact:
+    scale_admin_nodename: "{{ scale_admin_nodename }}"
+  when: hostvars[inventory_hostname].scale_admin_nodename is undefined
+
 - name: check | Assign default admin nodes
   set_fact:
      is_admin_node: true

--- a/roles/core/cluster/templates/NewNodeFile.j2
+++ b/roles/core/cluster/templates/NewNodeFile.j2
@@ -1,4 +1,4 @@
 {% for host in groups['scale_cluster_candidates'] | sort %}
-{{ hostvars[host].scale_daemon_nodename }}:{% if hostvars[host].scale_cluster_quorum | bool %}quorum{% else %}nonquorum{% endif %}-{% if hostvars[host].scale_cluster_manager | bool %}manager{% else %}client{% endif %}
-
+{{ hostvars[host].scale_daemon_nodename }}:{% if hostvars[host].scale_cluster_quorum | bool %}quorum{% else %}nonquorum{% endif %}-{% if hostvars[host].scale_cluster_manager | bool %}manager{% else %}client{% endif %}:{{ hostvars[host].scale_admin_nodename }}
 {% endfor %}
+

--- a/roles/core/precheck/defaults/main.yml
+++ b/roles/core/precheck/defaults/main.yml
@@ -49,6 +49,10 @@ scale_prepare_disable_selinux: false
 ## rules prior to running this role (e.g. as pre_tasks)
 scale_prepare_disable_firewall: false
 
+## For the Spectrum Scale daemon network the 'ListenAddress' needs to be set
+## at /etc/ssh/sshd_config to allow only the admin IP to login.
+## Set the scale_sshd_config_update to 'true' to update the sshd_config
+scale_sshd_config_update: false
 
 ## Temporary directory to copy installation package to
 ## (local package installation method)

--- a/roles/core/precheck/tasks/prepare.yml
+++ b/roles/core/precheck/tasks/prepare.yml
@@ -32,6 +32,17 @@
         line: PubkeyAuthentication yes
         state: present
       notify: reload-sshd
+
+    # prepare | Update ListenAddress at sshd_config for daemon network
+    - name: Update ListenAddress at /etc/ssh/sshd_config
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        state: present
+        regexp: '#ListenAddress 0.'
+        line: 'ListenAddress {{ ansible_fqdn }}'
+      notify: reload-sshd
+      when: scale_sshd_config_update is defined and scale_sshd_config_update|bool
+
   when: scale_prepare_enable_ssh_login | bool
 
 - meta: flush_handlers


### PR DESCRIPTION
  Implementation of gpfs daemon network to ansible toolkit

  Signed-off-by: Christoph Keil chkeil@de.ibm.com

```
[cluster01]
scale-11 scale_cluster_quorum=true scale_cluster_manager=true scale_zimon_collector=true scale_cluster_gui=false is_protocol_node=true  scale_admin_nodename=scale-13  scale_daermon_nodename=scale-13d
scale-12 scale_cluster_quorum=true scale_cluster_manager=true scale_zimon_collector=true scale_cluster_gui=false is_protocol_node=true  scale_admin_nodename=scale-13  scale_daemon_nodename=scale-13d

```
I will create a separate pull request to update the readme. 
