### PR TITLE
Adopt new syntax of stat module (checksum)

### DIFF
--- a/roles/callhome/node/tasks/install_local_pkg.yml
+++ b/roles/callhome/node/tasks/install_local_pkg.yml
@@ -5,6 +5,7 @@
     - name: install | Stat local installation package
       stat:
         path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
       register: scale_install_localpkg
 
     - name: install | Check local installation package
@@ -28,7 +29,7 @@
 
         - name: install | Compare checksums
           assert:
-            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
             msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!
@@ -139,4 +140,3 @@
   with_items:
   - "{{ scale_install_gpfs_java.files.0.path }}"
   - "{{ scale_install_gpfs_callhome.files.0.path }}"
-

--- a/roles/callhome/node/tasks/install_remote_pkg.yml
+++ b/roles/callhome/node/tasks/install_remote_pkg.yml
@@ -4,6 +4,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 - name: install | Check remote installation package
@@ -31,7 +32,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!
@@ -113,4 +114,3 @@
     with_items:
     - "{{ scale_install_gpfs_java.files.0.path }}"
     - "{{ scale_install_gpfs_callhome.files.0.path }}"
-

--- a/roles/core/node/tasks/install_local_pkg.yml
+++ b/roles/core/node/tasks/install_local_pkg.yml
@@ -5,6 +5,7 @@
     - name: install | Stat local installation package
       stat:
         path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
       register: scale_install_localpkg
 
     - name: install | Check local installation package
@@ -29,7 +30,7 @@
 
         - name: install | Compare checksums
           assert:
-            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
             msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!

--- a/roles/core/node/tasks/install_remote_pkg.yml
+++ b/roles/core/node/tasks/install_remote_pkg.yml
@@ -4,6 +4,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 - name: install | Check remote installation package
@@ -31,7 +32,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!

--- a/roles/gui/node/tasks/install_local_pkg.yml
+++ b/roles/gui/node/tasks/install_local_pkg.yml
@@ -5,6 +5,7 @@
     - name: install | Stat local installation package
       stat:
         path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
       register: scale_install_localpkg
 
     - name: install | Check local installation package
@@ -28,7 +29,7 @@
 
         - name: install | Compare checksums
           assert:
-            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
             msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!

--- a/roles/nfs/node/tasks/install_local_pkg.yml
+++ b/roles/nfs/node/tasks/install_local_pkg.yml
@@ -4,6 +4,7 @@
   - name: install | Stat local installation package
     stat:
      path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
     register: scale_install_localpkg
 
   - name: install | Check local installation package
@@ -28,7 +29,7 @@
 
     - name: install | Compare checksums
       assert:
-       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
        msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!

--- a/roles/nfs/node/tasks/install_remote_pkg.yml
+++ b/roles/nfs/node/tasks/install_remote_pkg.yml
@@ -4,6 +4,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 - name: install | Check remote installation package
@@ -31,7 +32,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!
@@ -160,7 +161,7 @@
     assert:
      that: scale_install_gpfs_nfs_ganesha.matched > 0
      msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
-  
+
   - name: install | Add GPFS package to list
     vars:
      current_package: "{{ item.path }}"
@@ -299,7 +300,7 @@
      debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
     with_items:
     - "{{ scale_install_gpfs_nfs_ganesha_debuginfo.files }}"
-    
+
   - name: remove debuginfo from packages
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"

--- a/roles/scale_ece/node/tasks/install_local_pkg.yml
+++ b/roles/scale_ece/node/tasks/install_local_pkg.yml
@@ -4,6 +4,7 @@
   - name: install | Stat local installation package
     stat:
      path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
     register: scale_install_localpkg
 
   - name: install | Check local installation package
@@ -29,7 +30,7 @@
 
     - name: install | Compare checksums
       assert:
-       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
        msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!

--- a/roles/scale_ece/node/tasks/install_remote_pkg.yml
+++ b/roles/scale_ece/node/tasks/install_remote_pkg.yml
@@ -4,6 +4,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 - name: install | Check remote installation package
@@ -30,7 +31,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!

--- a/roles/scale_fileauditlogging/node/tasks/install_local_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_local_pkg.yml
@@ -5,6 +5,7 @@
     - name: install | Stat local installation package
       stat:
         path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
       register: scale_install_localpkg
 
     - name: install | Check local installation package
@@ -28,7 +29,7 @@
 
         - name: install | Compare checksums
           assert:
-            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
             msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!

--- a/roles/scale_fileauditlogging/node/tasks/install_remote_pkg.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install_remote_pkg.yml
@@ -6,6 +6,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 
@@ -37,7 +38,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!

--- a/roles/smb/node/tasks/install_local_pkg.yml
+++ b/roles/smb/node/tasks/install_local_pkg.yml
@@ -4,6 +4,7 @@
   - name: install | Stat local installation package
     stat:
      path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
     register: scale_install_localpkg
 
   - name: install | Check local installation package
@@ -30,7 +31,7 @@
 
     - name: install | Compare checksums
       assert:
-       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
        msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!
@@ -184,7 +185,7 @@
      debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
     with_items:
     - "{{ scale_install_gpfs_smb_debuginfo.files }}"
-    
+
   - name: remove debuginfo from packages
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"

--- a/roles/smb/node/tasks/install_remote_pkg.yml
+++ b/roles/smb/node/tasks/install_remote_pkg.yml
@@ -4,6 +4,7 @@
 - name: install | Stat remote installation package
   stat:
     path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
   register: scale_install_remotepkg
 
 - name: install | Check remote installation package
@@ -31,7 +32,7 @@
       vars:
         md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
       assert:
-        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.md5
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
         msg: >-
           Checksums don't match. Please check integritiy of your remote
           installation package!
@@ -145,7 +146,6 @@
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
   when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution
-  
+
 - debug:
    msg: "{{ scale_install_all_packages }}"
-

--- a/roles/zimon/node/tasks/install_local_pkg.yml
+++ b/roles/zimon/node/tasks/install_local_pkg.yml
@@ -5,6 +5,7 @@
     - name: install | Stat local installation package
       stat:
         path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
       register: scale_install_localpkg
 
     - name: install | Check local installation package
@@ -28,7 +29,7 @@
 
         - name: install | Compare checksums
           assert:
-            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.md5
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
             msg: >-
               Checksums don't match. Please check integritiy of your local
               installation package!
@@ -103,7 +104,7 @@
 - name: install | Set package arch
   set_fact:
     package_arch: 'U'
-  when: ansible_distribution in scale_ubuntu_distribution 
+  when: ansible_distribution in scale_ubuntu_distribution
 
 - name: install | Set package arch
   set_fact:


### PR DESCRIPTION
The syntax of the `stat` module has changed: one needs to specify the `checksum_algorithm` (e.g. `md5`) and then the value of the file is accessible through the generic `checksum` field...

https://docs.ansible.com/ansible/2.9/modules/stat_module.html#stat-module

This should fix #90 and #261.