### PR TITLE
  Set correct path to SMB packages when Ubuntu20.04 is used.

### DIFF
--- a/roles/nfs/node/tasks/install_remote_pkg.yml
+++ b/roles/nfs/node/tasks/install_remote_pkg.yml
@@ -126,6 +126,11 @@
    scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
   when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
 
+- name: install | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
 - block:  ## when: host is defined as a protocol node
 
   - name: install | Find gpfs.smb (gpfs.smb) package

--- a/roles/nfs/node/tasks/install_repository.yml
+++ b/roles/nfs/node/tasks/install_repository.yml
@@ -1,8 +1,6 @@
 ---
 - name: Initialize
   set_fact:
-   scale_nfs_url: ""
-   scale_smb_url: ""
    gpgcheck: "yes"
 
 - name: Disable gpg check
@@ -48,7 +46,7 @@
 - name: install | smb path
   set_fact:
    scale_smb_url: 'smb_debs/ubuntu/'
-  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version >= '20'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
 
 - name: install | zimon path
   set_fact:

--- a/roles/smb/node/tasks/install_local_pkg.yml
+++ b/roles/smb/node/tasks/install_local_pkg.yml
@@ -136,7 +136,11 @@
    scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
   when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
 
-#
+- name: install | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
 
 # Find smb rpms
 

--- a/roles/smb/node/tasks/install_remote_pkg.yml
+++ b/roles/smb/node/tasks/install_remote_pkg.yml
@@ -96,6 +96,11 @@
    scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
   when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
 
+- name: install | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
 - block:  ## when: host is defined as a protocol node
 
   - name: install | Find gpfs.smb (gpfs.smb) package

--- a/roles/smb/node/tasks/install_repository.yml
+++ b/roles/smb/node/tasks/install_repository.yml
@@ -1,7 +1,6 @@
 ---
 - name: install | Initialize
   set_fact:
-   scale_smb_url: ""
    gpgcheck: "yes"
 
 - name: install | Disable gpg check


### PR DESCRIPTION
  Set correct path to SMB packages when Ubuntu20.04 is used.

  Signed-off-by: Christoph Keil <chkeil@de.ibm.com>