### PR TITLE
  Fix problem installing callhome packages on scale release lower 5.1…

### DIFF
--- a/roles/callhome/node/tasks/main.yml
+++ b/roles/callhome/node/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-# Install IBM Spectrum Scale (GPFS) Graphical User Interface (GUI)
+# Install IBM Spectrum Scale (GPFS) Callhome
 
 - import_tasks: install.yml
   tags: install
-  when: scale_callhome_params is defined and scale_callhome_params.is_enabled|bool
-
+  when: 
+    - scale_callhome_params is defined and scale_callhome_params.is_enabled|bool
+    - scale_version is version_compare('5.1.0', '<')
 

--- a/roles/callhome/node/tasks/zypper/install.yml
+++ b/roles/callhome/node/tasks/zypper/install.yml
@@ -1,6 +1,8 @@
 ---
 - name: install | Disable repo metadata gpg check
   command: "zypper modifyrepo --gpgcheck-allow-unsigned-repo --all"
+  args:
+    warn: false
 
 - name: install | Install GPFS Callhome packages
   zypper:


### PR DESCRIPTION
  Fix problem installing callhome packages on scale release lower 5.1.0

  With 5.1 callhome are include in gpfs.base package.
  For lower releases as 5.1.0-0 the callhome packages still need to instaled
  as separate packages.

  Signed-off-by: Christoph Keil <chkeil@de.ibm.com>