### PR TITLE
different approach to making nfs and smb tightly coupled

### DIFF
--- a/roles/nfs/node/tasks/main.yml
+++ b/roles/nfs/node/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - import_tasks: install.yml
   tags: install
-  when: scale_protocols is defined and scale_protocols.nfs|bool
+  when: scale_protocols is defined and (scale_protocols.nfs|bool or scale_protocols.smb|bool)

--- a/roles/nfs/precheck/tasks/check.yml
+++ b/roles/nfs/precheck/tasks/check.yml
@@ -3,11 +3,11 @@
   set_fact:
    scale_nfs_nodes_list: []
 
-- name: check | Check if nfs is enabled
+- name: check | Check if nfs or smb is enabled
   assert:
    that:
-   - scale_protocols.nfs|bool
-   fail_msg: "NFS is not enabled"
+   - scale_protocols.nfs|bool or scale_protocols.smb|bool
+   fail_msg: "NFS and SMB is not enabled"
 
 - name: check | Collect all nfs nodes
   set_fact:

--- a/roles/nfs/precheck/tasks/main.yml
+++ b/roles/nfs/precheck/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 # tasks file for precheck
 - import_tasks: check.yml
-  when: scale_protocols is defined and scale_protocols.nfs|bool
+  when: scale_protocols is defined and (scale_protocols.nfs|bool or scale_protocols.smb|bool)
   tags: prepare

--- a/roles/smb/node/tasks/install_local_pkg.yml
+++ b/roles/smb/node/tasks/install_local_pkg.yml
@@ -164,6 +164,30 @@
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
     - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: install | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
+    register: scale_install_gpfs_smb
+
+  - name: install | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
+
+  - name: install | Add GPFS smb package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
 
 - block:  ## when: host is defined as a protocol node
 

--- a/roles/smb/node/tasks/main.yml
+++ b/roles/smb/node/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 # Install IBM Spectrum Scale (SMB)
 - import_tasks: install.yml
-  when: scale_protocols is defined and scale_protocols.smb|bool
+  when: scale_protocols is defined and (scale_protocols.smb|bool or scale_protocols.nfs|bool)
   tags: install

--- a/roles/smb/precheck/tasks/check.yml
+++ b/roles/smb/precheck/tasks/check.yml
@@ -18,11 +18,11 @@
    - scale_smb_node_list|length > 0
    fail_msg: "No smb nodes configured"
 
-- name: check | Check if smb is enabled
+- name: check | Check if nfs or smb is enabled
   assert:
    that:
-   - scale_protocols.smb|bool
-   fail_msg: "SMB is not enabled"
+   - scale_protocols.smb|bool or scale_protocols.nfs|bool
+   fail_msg: "SMB and NFS is not enabled"
   run_once: true
 
 - name: check | Check if service smb is running

--- a/roles/smb/precheck/tasks/main.yml
+++ b/roles/smb/precheck/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 # tasks file for precheck
 - import_tasks: check.yml
-  when: scale_protocols is defined and scale_protocols.smb|bool
+  when: scale_protocols is defined and (scale_protocols.smb|bool or scale_protocols.nfs|bool)
   tags: prepare


### PR DESCRIPTION
This PR achieves the following:
- If NFS is installed, SMB will be automatically installed along with it.
- If SMB is installed, NFS will be automatically installed along with it.
- Solved incorrect package order installation error for smb in ubuntu (gpfs.smb-debuginfo package was getting installed before gpfs.smb)

Signed-off-by: Shubham Darokar (shubham.dipak.darokar1@ibm.com)