### PR TITLE
Issue when configure cesSharedRoot when none CES nodes in cluster.

### DIFF
--- a/roles/nfs/common/tasks/configure.yml
+++ b/roles/nfs/common/tasks/configure.yml
@@ -7,17 +7,17 @@
    scale_service_list: []
    scale_ces_nodes: ""
 
-- name: configure | Collect status of ces shared root
-  shell:
-   cmd: "{{ scale_command_path }}mmlsconfig | grep 'cesSharedRoot '"
+- name: configure | Collect status of cesSharedRoot
+  command: "{{ scale_command_path }}mmlsconfig cesSharedRoot"
   register: scale_ces_status
-  ignore_errors: true
+  delegate_to: "{{ scale_protocol_node_list.0 }}"
+  run_once: true
 
 - name: configure | Configuring cesSharedRoot
   command: "{{ scale_command_path }}mmchconfig cesSharedRoot={{ scale_protocols.mountpoint }}"
-  async: 45
-  poll: 5
-  when: scale_ces_status.rc > 0
+  when: "'undefined' in scale_ces_status.stdout"
+  delegate_to: "{{ scale_protocol_node_list.0 }}"
+  run_once: true
 
 - name: configure | Prepare server nodes string
   set_fact:


### PR DESCRIPTION
Issue when configure cesSharedRoot when none CES nodes in cluster.
It is not neccesary to issue the mmlscofig and mmchconfig command on each node at the cluster. 
The commands needs to be issue only one node.

  Signed-off-by: Christoph Keil <chkeil@de.ibm.com>