### PR TITLE
Fixed to keep stanza file inside /usr/lpp/mmfs

### DIFF
--- a/roles/core/cluster/tasks/storage_disk.yml
+++ b/roles/core/cluster/tasks/storage_disk.yml
@@ -87,6 +87,7 @@
         src: /var/tmp/StanzaFile.new.nsd
         dest: /usr/lpp/mmfs/
         mode: a+x
+        remote_src: yes
       ignore_errors: yes
       when:
         - scale_storage_stanzafile_new.size > 1

--- a/roles/core/cluster/tasks/storage_fs.yml
+++ b/roles/core/cluster/tasks/storage_fs.yml
@@ -125,6 +125,7 @@
         src: /var/tmp/StanzaFile.new.{{ item.item }}
         dest: /usr/lpp/mmfs/
         mode: a+x
+        remote_src: yes
       ignore_errors: yes
       when:
         - item.size is defined and item.size > 1
@@ -163,6 +164,7 @@
         src: /var/tmp/StanzaFile.new.{{ item.item }}
         dest: /usr/lpp/mmfs/
         mode: a+x
+        remote_src: yes
       ignore_errors: yes
       when:
         - item.size is defined and item.size > 1


### PR DESCRIPTION
Fixed to keep stanza file inside /usr/lpp/mmfs
Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>