### PR TITLE
Ansible independent upgrade role for all supported component

### DIFF
--- a/roles/core/upgrade/defaults/main.yml
+++ b/roles/core/upgrade/defaults/main.yml
@@ -1,0 +1,104 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) role -
+# either edit this file or define your own variables to override the defaults
+
+
+## Specify the Spectrum Scale version that you want to install on your nodes
+#scale_version: 4.1.1.0
+
+
+## Specify the URL of the (existing) Spectrum Scale YUM repository
+## (copy the contents of /usr/lpp/mmfs/.../gpfs_rpms to build your repository)
+#scale_install_repository_url: http://infraserv/
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the path to Spectrum Scale installation package on the remote system
+## (accessible on Ansible managed node)
+#scale_install_remotepkg_path: /path/to/Spectrum_Scale_Standard-{{ scale_version }}-{{ ansible_architecture }}-Linux-install
+
+## Specify the path to Spectrum Scale installation package on the local system
+## (accessible on Ansible control machine) - it will be copied to your nodes
+#scale_install_localpkg_path: /path/to/Spectrum_Scale_Standard-{{ scale_version }}-{{ ansible_architecture }}-Linux-install
+
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## Temporary directory to copy installation package to
+## (local package installation method)
+scale_install_localpkg_tmpdir_path: /tmp
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"
+
+## Enable/disable gpg key flag
+scale_enable_gpg_check: true
+
+## List of GPFS RPMs to install
+scale_install_gpfs_packages:
+  - gpfs.base
+  - gpfs.docs*
+  - gpfs.msg.en*
+  - gpfs.compression*
+  # Appropriate gpfs.gskit version will be installed automatically
+
+## List of GPFS RPMs to install (prior to version 5.0.2.0)
+scale_install_add_packages_pre502:
+  - gpfs.ext*
+
+## List of GPFS RPMs to install for building Linux kernel extension from source
+scale_install_gplsrc_packages:
+  - gpfs.gpl*
+
+
+## Define this variable to install Linux kernel extension from pre-built RPM
+## (instead of building it from source)
+#scale_install_gplbin_rpm: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
+
+## Note that required RPM can be built with `mmbuildgpl --build-package`
+
+## Specify the URL of the (existing) YUM repository from which to install
+## pre-built Linux kernel extension RPM
+#scale_install_gplbin_repository_url: http://infraserv/gplbin_rpms/
+
+## List of RPMs to install when installing Linux kernel extension
+## from pre-built RPM
+scale_install_gplbin_prereqs:
+  - glibc-devel
+
+## List of RPMs to install when building Linux kernel extension from source
+scale_build_gplsrc_prereqs:
+  - kernel-devel-{{ ansible_kernel }}
+  - kernel-headers-{{ ansible_kernel }}
+  - gcc-c++
+  - make
+
+## List of RPMs to install specific to rhel8 when building Linux kernel extension from source
+scale_build_gplsrc_el8_prereqs:
+  - elfutils
+  - elfutils-devel
+
+# Ubuntu buildgpl prereq
+scale_build_gplsrc_prereqs_deb:
+  - cpp
+  - gcc
+  - g++
+  - binutils
+  - make
+
+# Ubuntu buildgpl prereq
+scale_build_gplsrc_prereqs_zypp:
+  - kernel-devel
+  - cpp
+  - gcc
+  - gcc-c++
+  - glibc
+
+## List of RPMs to install when building Linux kernel extension from source on s390x
+scale_build_gplsrc_prereqs_s390x:
+  - kernel-devel-{{ ansible_kernel }}
+  - kernel-headers-{{ ansible_kernel }}
+  - make

--- a/roles/core/upgrade/handlers/main.yml
+++ b/roles/core/upgrade/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# Handlers for the common role for IBM Spectrum Scale (GPFS) cluster role
+# Handlers for the IBM Spectrum Scale (GPFS) node role
 # handlers file for node
 - name: yum-clean-metadata
   command: yum clean metadata

--- a/roles/core/upgrade/meta/main.yml
+++ b/roles/core/upgrade/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: core_node
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies:
+ - common

--- a/roles/core/upgrade/tasks/apt/install.yml
+++ b/roles/core/upgrade/tasks/apt/install.yml
@@ -1,0 +1,40 @@
+---
+#
+# Install or update packages
+#
+- block:  ## when: not scale_daemon_running
+    - block:
+        - name: upgrade | Upgrade GPFS packages
+          apt:
+            deb: "{{ item }}"
+            state: latest
+          register: scale_install_debpackageresult
+          with_items:
+            - "{{ scale_install_all_packages }}"
+
+        - name: upgrade | Upgrade GPFS License packages
+          apt:
+            deb: "{{ item }}"
+            state: latest
+          with_items:
+            - "{{ scale_install_license_packages }}"
+
+        - name: upgrade | Check if GPFS packages were updated
+          set_fact:
+            scale_install_updated: true
+          when:
+            - (scale_install_debpackageresult.changed)
+      when: scale_install_repository_url is not defined
+
+    - block:
+        - name: upgrade | Upgrade GPFS Core packages
+          package:
+           name: "{{ scale_install_all_packages }}"
+           state: present
+
+        - name: upgrade | Upgrade GPFS Core packages
+          package:
+           name: "{{ scale_install_license_packages }}"
+           state: present
+      when: scale_install_repository_url is defined
+  when: not scale_daemon_running

--- a/roles/core/upgrade/tasks/apt/install.yml
+++ b/roles/core/upgrade/tasks/apt/install.yml
@@ -30,11 +30,11 @@
         - name: upgrade | Upgrade GPFS Core packages
           package:
            name: "{{ scale_install_all_packages }}"
-           state: present
+           state: latest
 
         - name: upgrade | Upgrade GPFS Core packages
           package:
            name: "{{ scale_install_license_packages }}"
-           state: present
+           state: latest
       when: scale_install_repository_url is defined
   when: not scale_daemon_running

--- a/roles/core/upgrade/tasks/build.yml
+++ b/roles/core/upgrade/tasks/build.yml
@@ -1,0 +1,46 @@
+---
+# Build Linux kernel extension from source
+
+- block:  ## when: scale_install_gplbin_rpm is undefined
+#
+# Identify Linux Distribution
+#
+    - name: build | Identify RedHat distribution
+      set_fact:
+        scale_build_distribution: REDHAT_AS_LINUX
+      when:
+        ansible_distribution in scale_rhel_distribution or
+        ansible_distribution in scale_sles_distribution
+
+    - name: build | Identify OS distribution
+      set_fact:
+        scale_build_distribution: UBUNTU_AS_LINUX
+      when:
+        - ansible_distribution in scale_ubuntu_distribution
+
+    - name: build | Check Linux distribution
+      assert:
+        that: scale_build_distribution is defined
+        msg: >-
+          Unsupported Linux distribution {{ ansible_distribution }}!
+
+#
+# Build kernel extension
+#
+    - name: build | Compile GPL module
+      shell: export LINUX_DISTRIBUTION={{ scale_build_distribution }} ; /usr/lpp/mmfs/bin/mmbuildgpl --quiet
+      args:
+        creates: /lib/modules/{{ ansible_kernel }}/extra/mmfs26.ko
+
+    - name: build | Stat GPL module
+      stat:
+        path: /lib/modules/{{ ansible_kernel }}/extra/mmfs26.ko
+      register: scale_build_kmod
+
+    - name: build | Check GPL module
+      assert:
+        that: scale_build_kmod.stat.exists
+        msg: >-
+          Unable to build Linux kernel extension for running kernel
+          {{ ansible_kernel }}!
+  when: scale_install_gplbin_rpm is undefined

--- a/roles/core/upgrade/tasks/finalize.yml
+++ b/roles/core/upgrade/tasks/finalize.yml
@@ -1,0 +1,39 @@
+---
+# Print messages collected during play
+
+- block:  ## run_once: true
+    - name: finalize | Check if GPFS RPMs were updated
+      vars:
+        msg: |-
+          ######################################################################
+          Spectrum Scale packages were updated. Once all nodes in the cluster
+          run the new version, consider updating configuration information to
+          the latest format that is supported by the currently installed level:
+
+            mmchconfig release=LATEST
+
+          Furthermore, consider updating file systems to the latest format that
+          is supported by the currently installed level:
+
+            mmchfs fs1 -V full
+
+          Remember that nodes in remote clusters running an older version will
+          no longer be able to mount the file system!
+          ######################################################################
+      debug:
+        msg: "{{ msg.split('\n') }}"
+      when: true in ansible_play_hosts | map('extract', hostvars, 'scale_install_updated') | list
+      # TODO: print all hosts with scale_install_updated set: hostvars | selectattr('scale_install_updated')
+
+    - name: finalize | Check if configuration parameters were changed
+      vars:
+        msg: |-
+          ######################################################################
+          Configuration parameters were changed. Please restart Spectrum Scale
+          on all nodes for the new settings to take effect!
+          ######################################################################
+      debug:
+        msg: "{{ msg.split('\n') }}"
+      when: true in ansible_play_hosts | map('extract', hostvars, 'scale_config_changed') | list
+      # TODO: print all hosts with scale_daemon_running set: hostvars | selectattr('scale_daemon_running')
+  run_once: true

--- a/roles/core/upgrade/tasks/install.yml
+++ b/roles/core/upgrade/tasks/install.yml
@@ -1,0 +1,78 @@
+---
+# Install or update packages
+
+#
+# Choose installation method from configuration variables
+#
+- block:  ## run_once: true
+    - name: upgrade | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_repository_url is defined
+
+    - name: upgrade | Check for remotepkg installation method
+      set_fact:
+        scale_installmethod: remote_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is defined
+
+    - name: upgrade | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: upgrade | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: upgrade | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of packages
+#
+- name: upgrade | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+    scale_install_license_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- include_tasks: install_gplbin.yml
+  when: scale_install_gplbin_package is defined
+
+- include_tasks: install_license_pkg.yml
+  when: scale_install_remotepkg_path is defined or scale_install_localpkg_path is defined or scale_install_directory_pkg_path is defined
+
+- include_tasks: install_license_repository.yml
+  when: scale_install_repository_url is defined
+
+- meta: flush_handlers
+
+#
+# Install or update packages
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/core/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/core/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,203 @@
+---
+# directory package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package
+#
+
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    scale_gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS BASE
+#
+- name: upgrade | Find GPFS BASE (gpfs.base) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.base*{{ scale_architecture }}*
+  register: scale_install_gpfs_base
+
+- name: upgrade | Check valid GPFS BASE (gpfs.base) package
+  assert:
+    that: scale_install_gpfs_base.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ dir_path }}/gpfs.base*{{ scale_architecture }}*
+
+#
+# Find GPFS gpfs.docs
+#
+- name: upgrade | Find GPFS docs (gpfs.docs) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.docs*
+  register: scale_install_gpfs_doc
+
+- name: upgrade | Check valid GPFS docs (gpfs.docs) package
+  assert:
+    that: scale_install_gpfs_doc.matched > 0
+    msg: >-
+      No GPFS docs (gpfs.docs) package found:
+      {{ dir_path }}/gpfs.docs*
+
+#
+# Find GPFS gpfs.msg.en_US
+#
+- name: upgrade | Find gpfs.msg.en_US (gpfs.msg.en_US) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.msg.en*
+  register: scale_install_gpfs_msg
+
+- name: upgrade | Check valid GPFS (gpfs.msg.en_US) package
+  assert:
+    that: scale_install_gpfs_msg.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ dir_path }}/gpfs.msg.en*
+
+#
+# Find GPFS gpfs.compression
+#
+- name: upgrade | Find GPFS Compression (gpfs.compression) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.compression*{{ scale_architecture }}*
+  register: scale_install_gpfs_compression
+
+- name: upgrade | Check valid GPFS Compression(gpfs.compression) package
+  debug:
+    msg: >-
+      No GPFS Compression (gpfs.compression) package found:
+      {{ dir_path }}/gpfs.compression*{{ scale_architecture }}*
+  when: scale_install_gpfs_compression.matched < 1
+
+#
+# Find GSKit
+#
+- name: upgrade | Find Global Security Kit (GSKit) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.gskit*{{ scale_architecture }}*
+  register: scale_install_gpfs_gskit
+
+- name: upgrade | Check valid Global Security Kit (GSKit) package
+  assert:
+    that: scale_install_gpfs_gskit.matched > 0
+    msg: >-
+      No Global Security Kit (GSKit) package found:
+      {{ dir_path }}/gpfs.gskit*{{ scale_architecture }}*
+
+#
+# Add GPFS Packages
+#
+- name: upgrade | Add GPFS packages to list
+  vars:
+    current_package: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_base.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_doc.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_msg.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_gskit.files.0.path | basename }}"
+
+- name: upgrade | Add GPFS compression packages to list
+  vars:
+    current_package: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items: "{{ scale_install_gpfs_compression.files.0.path | basename }}"
+  when: scale_install_gpfs_compression.matched == 1
+
+- name: upgrade | Add GPFS packages to list (prior to version 5.0.2.0)
+  vars:
+    current_package: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_add_packages_pre502 }}"
+  when: scale_version is version_compare('5.0.2', '<=')
+
+#
+# Add GPFS Packages for building GPL module from source
+#
+
+- name: upgrade | Find GPFS gpl (gpfs.gpl) package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: gpfs.gpl*
+  register: scale_install_gpfs_gpl
+
+- name: upgrade | Check valid GPFS GPL (gpfs.gpl) package
+  assert:
+    that: scale_install_gpfs_gpl.matched > 0
+    msg: >-
+      No GPFS GPL (gpfs.gpl) package found:
+      {{ dir_path }}/gpfs.gpl*
+
+- name: upgrade | Add GPFS packages for building GPL module from source to list
+  vars:
+    current_package: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  when: scale_install_gplbin_package is undefined
+  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"
+
+#
+# Find ibm_cloud_workflows
+#
+- name: upgrade | Find workflows package
+  find:
+    paths: "{{ dir_path }}"
+    patterns: ibm_cloud_workflows*
+  register: scale_install_cloud_workflows
+
+- name: upgrade | Add workflows package from source to list
+  vars:
+    current_package: "{{ dir_path }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items: "{{ scale_install_cloud_workflows.files.0.path | basename }}"
+  when: scale_install_cloud_workflows.matched == 1

--- a/roles/core/upgrade/tasks/install_gplbin.yml
+++ b/roles/core/upgrade/tasks/install_gplbin.yml
@@ -1,0 +1,53 @@
+---
+# Install Linux kernel extension from pre-built package
+
+#
+# Configure YUM repository
+#
+- name: upgrade | Configure GPL module YUM repository
+  yum_repository:
+    name: spectrum-scale-gplbin
+    description: IBM Spectrum Scale (GPFS) GPL module
+    baseurl: "{{ scale_install_gplbin_repository_url }}"
+    gpgcheck: false
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_gplbin_repository_url is defined
+
+- name: upgrade | Configure GPL module repository
+  apt_repository:
+    name: spectrum-scale-gplbin
+    description: IBM Spectrum Scale (GPFS) GPL module
+    baseurl: "{{ scale_install_gplbin_repository_url }}"
+    gpgcheck: false
+    state: present
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_gplbin_repository_url is defined
+
+- name: upgrade | Configure GPL module repository
+  zypper_repository:
+    name: spectrum-scale-gplbin
+    description: IBM Spectrum Scale (GPFS) GPL module
+    baseurl: "{{ scale_install_gplbin_repository_url }}"
+    gpgcheck: false
+    state: present
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_gplbin_repository_url is defined
+#
+# Add kernel extension prereqs
+#
+- name: upgrade | Add dependencies for pre-built GPL module to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items: "{{ scale_install_gplbin_prereqs }}"
+
+#
+# Add kernel extension package
+#
+- name: upgrade | Add GPL module package to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ scale_install_gplbin_package ] }}"

--- a/roles/core/upgrade/tasks/install_license_pkg.yml
+++ b/roles/core/upgrade/tasks/install_license_pkg.yml
@@ -1,0 +1,83 @@
+---
+# Local license package installation method
+
+#
+# Find GPFS BASE
+#
+- name: upgrade | Find GPFS License (gpfs.license) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.license*{{ scale_architecture }}*
+  register: scale_install_gpfs_license
+
+- name: upgrade | Check valid GPFS License (gpfs.license) package
+  assert:
+    that: scale_install_gpfs_license.matched > 0
+    msg: >-
+      No GPFS License (gpfs.license) package found:
+      "{{ scale_gpfs_path_url }}/gpfs.license*{{ scale_architecture }}*"
+
+- name: upgrade | Check valid only one GPFS License (gpfs.license) package
+  assert:
+    that:
+      - scale_install_gpfs_license.matched > 0
+      - scale_install_gpfs_license.matched == 1
+    msg: >-
+      More than one GPFS License (gpfs.license) package found:
+      "{{ scale_gpfs_path_url }}/gpfs.license*{{ scale_architecture }}*"
+
+- name: upgrade | Find GPFS License package
+  vars:
+    gpfs_license_package: "{{ scale_install_gpfs_license.files.0.path | basename }}"
+  set_fact:
+    scale_gpfs_license_package: "{{ gpfs_license_package }}"
+
+- block:
+    #
+    # Find GPFS adv packgae
+    #
+    - name: upgrade | Find GPFS Advance (gpfs.adv) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.adv*{{ scale_architecture }}*
+      register: scale_install_gpfs_adv
+
+    #
+    # Find GPFS crypto packgae
+    #
+    - name: upgrade | Find GPFS crypto (gpfs.crypto) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.crypto*{{ scale_architecture }}*
+      register: scale_install_gpfs_crypto
+  when: 
+    - '"gpfs.license.std" not in scale_gpfs_license_package'
+    - '"gpfs.license.da" not in scale_gpfs_license_package'
+
+
+#
+# Add GPFS packages
+#
+- name: upgrade | Add GPFS License packages to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_license_packages: "{{ scale_install_license_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_license.files.0.path | basename }}"
+
+#
+# Add GPFS packages
+#
+- name: upgrade | Add GPFS Dependent License packages to list
+  vars:
+    license_package: "{{ scale_install_gpfs_license.files.0.path | basename }}"
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_license_packages: "{{ scale_install_license_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_adv.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_crypto.files.0.path | basename }}"
+  when: 
+    - '"gpfs.license.std" not in scale_gpfs_license_package'
+    - '"gpfs.license.da" not in scale_gpfs_license_package'

--- a/roles/core/upgrade/tasks/install_license_repository.yml
+++ b/roles/core/upgrade/tasks/install_license_repository.yml
@@ -1,0 +1,73 @@
+---
+# YUM repository installation method
+
+#
+# Configure license package installation repository
+#
+- name: upgrade | Get license package
+  yum:
+    list: gpfs.license.*
+  register: package_name_version
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+
+- name: Find license package
+  shell:
+   cmd: apt-cache show gpfs.license.*
+  register: package_name
+  when:
+  - ansible_pkg_mgr == 'apt'
+
+- name: upgrade | Get license package
+  shell:
+   cmd: zypper info gpfs.license.* | grep Name | cut -d ':' -f 2 | tr -d '[:space:]'
+  register: package_name_version_zypp
+  when:
+    - ansible_pkg_mgr == 'zypper'
+
+- name: upgrade | Check valid only one GPFS License (gpfs.license) RPM
+  assert:
+    that: package_name_version.results | selectattr("yumstate", "match", "available") | list | length >= 1
+    msg: >-
+      More than one GPFS License (gpfs.license) RPM found:
+      "gpfs.license*{{ scale_architecture }}*"
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+
+- name: upgrade | Find GPFS License package
+  vars:
+    gpfs_license_package: "{{ package_name_version.results|selectattr('yumstate','match','available')|map(attribute='name')|list }}"
+  set_fact:
+    scale_gpfs_license_package: "{{ gpfs_license_package }}"
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+
+- name: upgrade | Find GPFS License package
+  set_fact:
+   scale_gpfs_license_package: "{{ package_name.stdout_lines.0[9:] }}"
+  when:
+  - ansible_pkg_mgr == 'apt'
+
+- name: upgrade | Find GPFS License package
+  set_fact:
+   scale_gpfs_license_package: "{{ package_name_version_zypp.stdout }}" 
+  when:
+  - ansible_pkg_mgr == 'zypper'
+
+- name: upgrade | Add GPFS license packages to list
+  set_fact:
+    scale_install_license_packages: "{{ scale_install_license_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_gpfs_license_package }}"
+    - gpfs.adv
+    - gpfs.crypto
+  when: 
+    - '"gpfs.license.std" not in scale_gpfs_license_package'
+    - '"gpfs.license.da" not in scale_gpfs_license_package'
+
+- name: upgrade | Add GPFS license packages to list
+  set_fact:
+    scale_install_license_packages: "{{ scale_gpfs_license_package }}"
+  when: 
+     - '"gpfs.license.std" in scale_gpfs_license_package'
+     - '"gpfs.license.da" in scale_gpfs_license_package'

--- a/roles/core/upgrade/tasks/install_local_pkg.yml
+++ b/roles/core/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,244 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
+      register: scale_install_localpkg
+
+    - name: upgrade | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+
+#
+# Optionally, verify package checksum
+#
+    - name: upgrade | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: upgrade | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: upgrade | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: upgrade | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: upgrade | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+
+#
+# Delete installation package
+#
+- name: upgrade | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+# Copy and import gpg key on RHEL and SLES if gpfs version >= 5.0.5.0
+- block:
+  - name: check | Copy key
+    copy:
+     src: "{{ scale_gpgKey_src }}"
+     dest: "{{ scale_gpgKey_dest }}"
+     remote_src: yes
+
+  - rpm_key:
+     state: present
+     key: "{{ scale_gpgKey_dest }}SpectrumScale_public_key.pgp"
+  when: ((ansible_distribution in scale_sles_distribution or ansible_distribution in scale_rhel_distribution)
+         and scale_enable_gpg_check and scale_version >= "5.0.5.0")
+
+#
+# Find GPFS BASE
+#
+- name: upgrade | Find GPFS BASE (gpfs.base) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.base*{{ scale_architecture }}*
+  register: scale_install_gpfs_base
+
+- name: upgrade | Check valid GPFS BASE (gpfs.base) package
+  assert:
+    that: scale_install_gpfs_base.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ scale_gpfs_path_url }}/gpfs.base*{{ scale_architecture }}*
+
+#
+# Find GPFS gpfs.docs
+#
+- name: upgrade | Find GPFS docs (gpfs.docs) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.docs*
+  register: scale_install_gpfs_doc
+
+- name: upgrade | Check valid GPFS docs (gpfs.docs) package
+  assert:
+    that: scale_install_gpfs_doc.matched > 0
+    msg: >-
+      No GPFS docs (gpfs.docs) package found:
+      {{ scale_gpfs_path_url }}/gpfs.docs*
+
+#
+# Find GPFS gpfs.msg.en_US
+#
+- name: upgrade | Find gpfs.msg.en_US (gpfs.msg.en_US) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.msg.en*
+  register: scale_install_gpfs_msg
+
+- name: upgrade | Check valid GPFS (gpfs.msg.en_US) package
+  assert:
+    that: scale_install_gpfs_msg.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ scale_gpfs_path_url }}/gpfs.msg.en*
+
+#
+# Find GPFS gpfs.compression
+#
+- name: upgrade | Find GPFS Compression (gpfs.compression) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.compression*{{ scale_architecture }}*
+  register: scale_install_gpfs_compression
+
+- name: upgrade | Check valid GPFS Compression(gpfs.compression) package
+  assert:
+    that: scale_install_gpfs_compression.matched > 0
+    msg: >-
+      No GPFS Compression (gpfs.compression) package found:
+      {{ scale_gpfs_path_url }}/gpfs.compression*{{ scale_architecture }}*
+
+#
+# Find GSKit
+#
+- name: upgrade | Find Global Security Kit (GSKit) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.gskit*{{ scale_architecture }}*
+  register: scale_install_gpfs_gskit
+
+- name: upgrade | Check valid Global Security Kit (GSKit) package
+  assert:
+    that: scale_install_gpfs_gskit.matched > 0
+    msg: >-
+      No Global Security Kit (GSKit) package found:
+      {{ scale_gpfs_path_url }}/gpfs.gskit*{{ scale_architecture }}*
+
+#
+# Add GPFS packages
+#
+- name: upgrade | Add GPFS packages to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_base.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_doc.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_msg.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_gskit.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_compression.files.0.path | basename }}"
+
+- name: upgrade | Add GPFS packages to list (prior to version 5.0.2.0)
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_add_packages_pre502 }}"
+  when: scale_version is version_compare('5.0.2', '<=')
+
+#
+# Add GPFS packages for building GPL module from source
+#
+
+- name: upgrade | Find GPFS gpl (gpfs.gpl) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.gpl*
+  register: scale_install_gpfs_gpl
+
+- name: upgrade | Check valid GPFS GPL (gpfs.gpl) package
+  assert:
+    that: scale_install_gpfs_gpl.matched > 0
+    msg: >-
+      No GPFS GPL (gpfs.gpl) package found:
+      {{ scale_gpfs_path_url }}/gpfs.gpl*
+
+- name: upgrade | Add GPFS packages for building GPL module from source to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  when: scale_install_gplbin_package is undefined
+  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"

--- a/roles/core/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/core/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,216 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+# Copy and import gpg key on RHEL and SLES if gpfs version >= 5.0.5.0
+- block:
+    - name: check | Copy key
+      copy:
+        src: "{{ scale_gpgKey_src }}"
+        dest: "{{ scale_gpgKey_dest }}"
+        remote_src: yes
+
+    - rpm_key:
+       state: present
+       key: "{{ scale_gpgKey_dest }}SpectrumScale_public_key.pgp"
+       
+  when: ((ansible_distribution in scale_sles_distribution or ansible_distribution in scale_rhel_distribution)
+         and scale_enable_gpg_check and scale_version >= "5.0.5.0")
+
+#
+# Find GPFS BASE
+#
+- name: upgrade | Find GPFS BASE (gpfs.base) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.base*{{ scale_architecture }}*
+  register: scale_install_gpfs_base
+
+- name: upgrade | Check valid GPFS BASE (gpfs.base) package
+  assert:
+    that: scale_install_gpfs_base.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ scale_gpfs_path_url }}/gpfs.base*{{ scale_architecture }}*
+
+#
+# Find GPFS gpfs.docs
+#
+- name: upgrade | Find GPFS docs (gpfs.docs) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.docs*
+  register: scale_install_gpfs_doc
+
+- name: upgrade | Check valid GPFS docs (gpfs.docs) package
+  assert:
+    that: scale_install_gpfs_doc.matched > 0
+    msg: >-
+      No GPFS docs (gpfs.docs) package found:
+      {{ scale_gpfs_path_url }}/gpfs.docs*
+
+#
+# Find GPFS gpfs.msg.en_US
+#
+- name: upgrade | Find gpfs.msg.en_US (gpfs.msg.en_US) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.msg.en*
+  register: scale_install_gpfs_msg
+
+- name: upgrade | Check valid GPFS (gpfs.msg.en_US) package
+  assert:
+    that: scale_install_gpfs_msg.matched > 0
+    msg: >-
+      No GPFS BASE (gpfs.base) package found:
+      {{ scale_gpfs_path_url }}/gpfs.msg.en*
+
+#
+# Find GPFS gpfs.compression
+#
+- name: upgrade | Find GPFS Compression (gpfs.compression) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.compression*{{ scale_architecture }}*
+  register: scale_install_gpfs_compression
+
+- name: upgrade | Check valid GPFS Compression(gpfs.compression) package
+  assert:
+    that: scale_install_gpfs_compression.matched > 0
+    msg: >-
+      No GPFS Compression (gpfs.compression) package found:
+      {{ scale_gpfs_path_url }}/gpfs.compression*{{ scale_architecture }}*
+
+#
+# Find GSKit
+#
+- name: upgrade | Find Global Security Kit (GSKit) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.gskit*{{ scale_architecture }}*
+  register: scale_install_gpfs_gskit
+
+- name: upgrade | Check valid Global Security Kit (GSKit) package
+  assert:
+    that: scale_install_gpfs_gskit.matched > 0
+    msg: >-
+      No Global Security Kit (GSKit) package found:
+      {{ scale_gpfs_path_url }}/gpfs.gskit*{{ scale_architecture }}*
+
+#
+# Add GPFS packages
+#
+- name: upgrade | Add GPFS packages to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_base.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_doc.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_msg.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_gskit.files.0.path | basename }}"
+    - "{{ scale_install_gpfs_compression.files.0.path | basename }}"
+
+- name: upgrade | Add GPFS packages to list (prior to version 5.0.2.0)
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_add_packages_pre502 }}"
+  when: scale_version is version_compare('5.0.2', '<=')
+
+#
+# Add GPFS packages for building GPL module from source
+#
+
+- name: upgrade | Find GPFS gpl (gpfs.gpl) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.gpl*
+  register: scale_install_gpfs_gpl
+
+- name: upgrade | Check valid GPFS GPL (gpfs.gpl) package
+  assert:
+    that: scale_install_gpfs_gpl.matched > 0
+    msg: >-
+      No GPFS GPL (gpfs.gpl) package found:
+      {{ scale_gpfs_path_url }}/gpfs.gpl*
+
+- name: upgrade | Add GPFS packages for building GPL module from source to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  when: scale_install_gplbin_package is undefined
+  with_items: "{{ scale_install_gpfs_gpl.files.0.path | basename }}"

--- a/roles/core/upgrade/tasks/install_repository.yml
+++ b/roles/core/upgrade/tasks/install_repository.yml
@@ -7,6 +7,7 @@
 - name: Initialize
   set_fact:
    gpgcheck: "yes"
+   is_scale_java_pkg_installed: false
 
 - name: Disable gpg check
   set_fact:
@@ -93,3 +94,42 @@
     scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
   when: scale_install_gplbin_package is undefined
   with_items: "{{ scale_install_gplsrc_packages }}"
+
+- name: upgrade | Check if gpfs java package is installed
+  shell: rpm -q gpfs.java
+  register: is_gpfsjava_package_installed
+  failed_when: no
+  changed_when: no
+  args:
+    warn: false
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf' or ansible_pkg_mgr == 'zypper'
+
+- name: upgrade | Set if gpfs java package is installed
+  set_fact:
+    is_scale_java_pkg_installed: true
+  when:
+     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf' or ansible_pkg_mgr == 'zypper'
+     - is_gpfsjava_package_installed.rc == 0
+
+- name: upgrade | Check if gpfs java package is installed
+  shell: dpkg -l | grep gpfs.java | awk "{print $1}" |  grep ii
+  register: is_gpfsjava_apt_package_installed
+  failed_when: no
+  changed_when: no
+  args:
+    warn: false
+  when: ansible_pkg_mgr == 'apt'
+
+- name: upgrade | Set if gpfs java package installed
+  set_fact:
+    is_scale_java_pkg_installed: true
+  when:
+     - ansible_pkg_mgr == 'apt'
+     - is_gpfsjava_apt_package_installed.rc == 0
+
+- name: upgrade | Add GPFS java packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - gpfs.java*
+  when: (is_scale_java_pkg_installed | bool)

--- a/roles/core/upgrade/tasks/install_repository.yml
+++ b/roles/core/upgrade/tasks/install_repository.yml
@@ -1,0 +1,95 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+# Copy and import gpg key on RHEL and SLES if gpfs version >= 5.0.5.0
+- block:
+    - name: check | Copy key
+      get_url:
+        url: "{{ scale_gpgKey_repository_src }}"
+        dest: "{{ scale_gpgKey_dest }}"
+
+    - rpm_key:
+        state: present
+        key: "{{ scale_gpgKey_dest }}/SpectrumScale_public_key.pgp"
+  when: ((ansible_distribution in scale_sles_distribution or ansible_distribution in scale_rhel_distribution)
+    and scale_enable_gpg_check and scale_version >= "5.0.5.0")
+
+- name: upgrade | Configure GPFS YUM repository
+  yum_repository:
+    name: spectrum-scale-gpfs
+    description: IBM Spectrum Scale (GPFS)
+    baseurl: "{{ scale_install_repository_url }}gpfs_rpms/"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+#
+# Configure apt repository
+#
+- name: upgrade | Configure core APT repository
+  apt_repository:
+    filename: spectrum-scale-core-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}gpfs_debs/ ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (core debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+#
+# Configure zypper repository
+#
+- name: upgrade | Configure GPFS repository
+  zypper_repository:
+    name: spectrum-scale-gpfs
+    description: IBM Spectrum Scale (GPFS)
+    repo: "{{ scale_install_repository_url }}gpfs_rpms/"
+    disable_gpg_check: yes
+    state: present
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+#
+# Add GPFS packages
+#
+- name: upgrade | Add GPFS packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_packages }}"
+    - gpfs.gskit
+
+- name: upgrade | Add GPFS packages to list (prior to version 5.0.2.0)
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_install_add_packages_pre502 }}"
+  when: scale_version is version_compare('5.0.2', '<=')
+
+#
+# Add GPFS packages for building GPL module from source
+#
+- name: upgrade | Add GPFS packages for building GPL module from source to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  when: scale_install_gplbin_package is undefined
+  with_items: "{{ scale_install_gplsrc_packages }}"

--- a/roles/core/upgrade/tasks/main.yml
+++ b/roles/core/upgrade/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# Install and configure IBM Spectrum Scale (GPFS)
+
+- import_tasks: install.yml
+  tags: install
+
+- import_tasks: build.yml
+  tags: build

--- a/roles/core/upgrade/tasks/yum/install.yml
+++ b/roles/core/upgrade/tasks/yum/install.yml
@@ -1,0 +1,74 @@
+---
+# Install or update packages
+
+#
+# Install or update packages
+#
+- name: upgrade | Initialize
+  set_fact:
+    scale_disable_gpgcheck: "no"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+    scale_disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- block:  ## when: not scale_daemon_running
+    - block:
+        - name: upgrade | List installed GPFS packages
+          yum:
+            list: gpfs.base
+            disablerepo: spectrum-scale-gpfs
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_packagelist
+          when: ansible_pkg_mgr == 'yum'
+
+        - name: upgrade | Upgrade GPFS packages
+          yum:
+            name: "{{ scale_install_all_packages }}"
+            state: latest
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_packageresult
+          when: ansible_pkg_mgr == 'yum'
+
+        - name: upgrade | Upgrade GPFS License packages
+          yum:
+            name: "{{ scale_install_license_packages }}"
+            state: latest
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_license_packageresult
+          when: ansible_pkg_mgr == 'yum'
+
+        - name: upgrade | List installed GPFS packages
+          dnf:
+            list: gpfs.base
+            disablerepo: spectrum-scale-gpfs
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_dnfpackagelist
+          when: ansible_pkg_mgr == 'dnf'
+
+        - name: upgrade | Upgrade GPFS packages
+          dnf:
+            name: "{{ scale_install_all_packages }}"
+            state: latest
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_dnfpackageresult
+          when: ansible_pkg_mgr == 'dnf'
+
+        - name: upgrade | Upgrade GPFS License packages
+          dnf:
+            name: "{{ scale_install_license_packages }}"
+            state: latest
+            disable_gpg_check: "{{ scale_disable_gpgcheck }}"
+          register: scale_install_license_dnfpackageresult
+          when: ansible_pkg_mgr == 'dnf'
+
+        - name: upgrade | Check if GPFS packages were updated
+          set_fact:
+            scale_install_updated: true
+          when:
+            - ("'installed' in scale_install_packagelist.results | map(attribute='yumstate') | list") or
+              ("'installed' in scale_install_dnfpackagelist.results | map(attribute='yumstate' | list")
+            - (scale_install_packageresult.changed) or (scale_install_dnfpackageresult.changed)
+      when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+  when: not scale_daemon_running

--- a/roles/core/upgrade/tasks/zypper/install.yml
+++ b/roles/core/upgrade/tasks/zypper/install.yml
@@ -4,11 +4,6 @@
 #
 - block:  ## when: not scale_daemon_running
     - block:
-        - name: upgrade | dependencies package
-          zypper:
-            name: binutils
-            state: present
-
         - name: upgrade | Upgrade GPFS packages
           zypper:
             name: "{{ scale_install_all_packages }}"

--- a/roles/core/upgrade/tasks/zypper/install.yml
+++ b/roles/core/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,31 @@
+---
+#
+# Install or update packages
+#
+- block:  ## when: not scale_daemon_running
+    - block:
+        - name: upgrade | dependencies package
+          zypper:
+            name: binutils
+            state: present
+
+        - name: upgrade | Upgrade GPFS packages
+          zypper:
+            name: "{{ scale_install_all_packages }}"
+            state: latest
+            disable_gpg_check: no
+          register: scale_install_zypppackageresult
+
+        - name: upgrade | Upgrade GPFS License packages
+          zypper:
+            name: "{{ scale_install_license_packages }}"
+            state: latest
+            disable_gpg_check: no
+          register: scale_install_license_packageresult
+
+        - name: upgrade | Check if GPFS packages were updated
+          set_fact:
+            scale_install_updated: true
+          when:
+            - (scale_install_zypppackageresult.changed)
+  when: not scale_daemon_running

--- a/roles/core/upgrade/tests/inventory
+++ b/roles/core/upgrade/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/core/upgrade/tests/test.yml
+++ b/roles/core/upgrade/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - node

--- a/roles/core/upgrade/vars/main.yml
+++ b/roles/core/upgrade/vars/main.yml
@@ -1,0 +1,38 @@
+---
+# Variables for the IBM Spectrum Scale (GPFS) role -
+# these variables are *not* meant to be overridden
+
+
+## Minimum Spectrum Scale version that this role was tested with
+scale_minversion: 4.1.1
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Supported package managers
+scale_pkg_mgr:
+  - yum
+  - dnf
+  - apt
+  - zypper
+
+## Remember if RPMs were updated or not
+scale_install_updated: false
+
+## Remember if config params were changed or not
+scale_config_changed: false
+
+## Supported scale os distrubution
+scale_ubuntu_distribution:
+  - Ubuntu
+  - Debian
+
+## Supported scale os distrubution
+scale_rhel_distribution:
+  - RedHat
+  - CentOS
+
+## Supported scale os distrubution
+scale_sles_distribution:
+  - SLES
+  - Suse

--- a/roles/gui/upgrade/defaults/main.yml
+++ b/roles/gui/upgrade/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) Graphical User Interface (GUI) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale GUI YUM repository
+## (copy the contents of /usr/lpp/mmfs/.../gpfs_rpms/ to build your repository)
+# scale_install_repository_url: http://infraserv/
+
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## List of RPMs to install on GUI nodes
+scale_gui_packages:
+  - gpfs.gui
+  - gpfs.java
+
+## Node's default GUI collector role -
+## you'll likely want to define per-node roles in your inventory
+scale_cluster_gui: false
+
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv
+
+# Hide the Callhome not enabled
+scale_gui_hide_tip_callhome: false

--- a/roles/gui/upgrade/meta/main.yml
+++ b/roles/gui/upgrade/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: gui_node
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) Graphical User Interface (GUI)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+  - core/common

--- a/roles/gui/upgrade/tasks/apt/install.yml
+++ b/roles/gui/upgrade/tasks/apt/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update packages
+#
+- block:
+    - name: upgrade | Upgrade GPFS GUI packages
+      package:
+        name: "{{ scale_install_all_packages }}"
+        state: latest
+      when: scale_install_repository_url is defined
+
+    - name: upgrade | Upgrade GPFS GUI packages
+      apt:
+        deb: "{{ item }}"
+        state: latest
+      with_items:
+        - "{{ scale_install_all_packages }}"
+      when: scale_install_repository_url is not defined

--- a/roles/gui/upgrade/tasks/install.yml
+++ b/roles/gui/upgrade/tasks/install.yml
@@ -1,0 +1,69 @@
+---
+# Install or update packages
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - name: upgrade | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_repository_url is defined
+
+    - name: upgrade | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: upgrade | Check for remotepkg installation method
+      set_fact:
+        scale_installmethod: remote_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is defined
+
+    - name: upgrade | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: upgrade | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of packages
+#
+- name: upgrade | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- meta: flush_handlers
+
+#
+# Install or update packages
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/gui/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/gui/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,89 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    scale_gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS GUI
+#
+- block:  ## when: host is defined as a gui node
+    - name: upgrade | Find GPFS GUI (gpfs.gui) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.gui*
+      register: scale_install_gpfs_gui
+
+    - name: upgrade | Check valid GPFS GUI (gpfs.gui) package
+      assert:
+        that: scale_install_gpfs_gui.matched > 0
+        msg: >-
+          No GPFS GUI (gpfs.gui) package found:
+          "{{ scale_gpfs_path_url }}/gpfs_packages/gpfs.gui*"
+    #
+    # Find GPFS gpfs.java
+    #
+    - name: upgrade | Find GPFS java (gpfs.java) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.java*{{ scale_architecture }}*
+      register: scale_install_gpfs_java
+
+    - name: upgrade | Check valid GPFS java (gpfs.java) package
+      assert:
+        that: scale_install_gpfs_java.matched > 0
+        msg: >-
+          No GPFS java (gpfs.java) package found:
+          "{{ scale_gpfs_path_url }}/gpfs.java*{{ scale_architecture }}*"
+
+    - name: upgrade | Add GPFS GUI packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_gui.files.0.path | basename }}"
+        - "{{ scale_install_gpfs_java.files.0.path | basename }}"

--- a/roles/gui/upgrade/tasks/install_local_pkg.yml
+++ b/roles/gui/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,139 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
+      register: scale_install_localpkg
+
+    - name: upgrade | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: upgrade | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: upgrade | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: upgrade | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: upgrade | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: upgrade | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: upgrade | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+#
+# Find GPFS GUI
+#
+- block:  ## when: host is defined as a gui node
+    - name: upgrade | Find GPFS GUI (gpfs.gui) packages
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.gui*
+      register: scale_install_gpfs_gui
+
+    - name: upgrade | Check valid GPFS GUI (gpfs.gui) packages
+      assert:
+        that: scale_install_gpfs_gui.matched > 0
+        msg: >-
+          No GPFS GUI (gpfs.gui) packages found:
+          "{{ scale_gpfs_path_url }}/gpfs.gui*"
+    #
+    # Find GPFS gpfs.java
+    #
+    - name: upgrade | Find GPFS java (gpfs.java) packages
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.java*{{ scale_architecture }}*
+      register: scale_install_gpfs_java
+
+    - name: upgrade | Check valid GPFS java (gpfs.java) package
+      assert:
+        that: scale_install_gpfs_java.matched > 0
+        msg: >-
+          No GPFS java (gpfs.java) package found:
+          "{{ scale_gpfs_path_url }}/gpfs.java*{{ scale_architecture }}*"
+
+    - name: upgrade | Add GPFS GUI packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_java.files.0.path | basename }}"
+        - "{{ scale_install_gpfs_gui.files.0.path | basename }}"

--- a/roles/gui/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/gui/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,113 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs__rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs__rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+#
+# Find GPFS GUI
+#
+- block:  ## when: host is defined as a gui node
+    - name: upgrade | Find GPFS GUI (gpfs.gui) packages
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.gui*
+      register: scale_install_gpfs_gui
+
+    - name: upgrade | Check valid GPFS GUI (gpfs.gui) packages
+      assert:
+        that: scale_install_gpfs_gui.matched > 0
+        msg: >-
+          No GPFS GUI (gpfs.gui) packages found:
+          "{{ scale_gpfs_path_url }}/gpfs.gui*"
+    #
+    # Find GPFS gpfs.java
+    #
+    - name: upgrade | Find GPFS java (gpfs.java) packages
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.java*{{ scale_architecture }}*
+      register: scale_install_gpfs_java
+
+    - name: upgrade | Check valid GPFS java (gpfs.java) package
+      assert:
+        that: scale_install_gpfs_java.matched > 0
+        msg: >-
+          No GPFS java (gpfs.java) package found:
+          "{{ scale_gpfs_path_url }}/gpfs.java*{{ scale_architecture }}*"
+
+    - name: upgrade | Add GPFS GUI packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_java.files.0.path | basename }}"
+        - "{{ scale_install_gpfs_gui.files.0.path | basename }}"

--- a/roles/gui/upgrade/tasks/install_repository.yml
+++ b/roles/gui/upgrade/tasks/install_repository.yml
@@ -1,0 +1,62 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: upgrade | Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Configure GUI YUM repository
+  yum_repository:
+    name: spectrum-scale-gui
+    description: IBM Spectrum Scale (GUI)
+    baseurl: "{{ scale_install_repository_url }}gpfs_rpms/"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure gui APT repository
+  apt_repository:
+    filename: spectrum-scale-gui-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}gpfs_debs/ ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (GUI debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure GUI repository
+  zypper_repository:
+    name: spectrum-scale-gui
+    description: IBM Spectrum Scale (GUI)
+    repo: "{{ scale_install_repository_url }}/gpfs_rpms/"
+    disable_gpg_check: no
+    state: present
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+#
+# Add GUI RPMs
+#
+
+- name: upgrade | Add GUI RPMs to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_gui_packages }}"

--- a/roles/gui/upgrade/tasks/main.yml
+++ b/roles/gui/upgrade/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# Install IBM Spectrum Scale (GPFS) Graphical User Interface (GUI)
+
+- import_tasks: install.yml
+  tags: install

--- a/roles/gui/upgrade/tasks/yum/install.yml
+++ b/roles/gui/upgrade/tasks/yum/install.yml
@@ -1,0 +1,25 @@
+---
+#
+# Install or update packages
+#
+- name: upgrade | Initialize
+  set_fact:
+    scale_disable_gpgcheck: "no"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+    scale_disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- block:  ## when: rhel8 node
+    - name: upgrade | Upgrade prereqs for GUI from source
+      dnf:
+        name: "{{ scale_gui_el8_prereqs }}"
+        state: present
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | Upgrade GPFS GUI packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: latest
+    disable_gpg_check: "{{ scale_disable_gpgcheck }}"

--- a/roles/gui/upgrade/tasks/zypper/install.yml
+++ b/roles/gui/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,7 @@
+---
+- block:
+    - name: upgrade | Upgrade GPFS GUI packages
+      zypper:
+          name: "{{ scale_install_all_packages }}"
+          state: latest
+          disable_gpg_check: no

--- a/roles/gui/upgrade/vars/main.yml
+++ b/roles/gui/upgrade/vars/main.yml
@@ -1,0 +1,13 @@
+---
+# Variables for the IBM Spectrum Scale (GUI) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"
+
+scale_gui_el8_prereqs:
+  - iptables

--- a/roles/nfs/upgrade/defaults/main.yml
+++ b/roles/nfs/upgrade/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Default variables for the IBM Spectrum Scale (NFS) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale YUM/apt/zypper repository
+#scale_install_nfs_repository_rpms: http://<ip>/ganesha_rpms/
+#scale_install_nfs_repository_debs: http://<ip>/ganesha_debs/ubuntu16
+#scale_install_nfs_repository_rpms_sles: http://<ip>/ganesha_rpms/sles12
+
+## List of NFS RPMs to install
+scale_nfs_rpms:
+- gpfs.nfs-ganesha-gpfs
+- gpfs.nfs-ganesha
+- gpfs.nfs-ganesha-utils
+
+## List of NFS debian package to install
+scale_nfs_debs:
+- gpfs.nfs-ganesha-gpfs
+- gpfs.nfs-ganesha
+- gpfs.nfs-ganesha-doc
+- gpfs.python-nfs-ganesha
+
+## pm ganesha package for nfs performance monitoring
+scale_pm_package:
+  - gpfs.pm-ganesha
+## Temporary directory to copy installation package to
+## (local package installation method)
+scale_install_localpkg_tmpdir_path: /tmp
+
+## Flag to install ganesha debug package
+install_debuginfo: true

--- a/roles/nfs/upgrade/handlers/main.yml
+++ b/roles/nfs/upgrade/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-# Handlers for the common role for IBM Spectrum Scale (GPFS) cluster role
 # handlers file for node
 - name: yum-clean-metadata
   command: yum clean metadata

--- a/roles/nfs/upgrade/meta/main.yml
+++ b/roles/nfs/upgrade/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: nfs_node
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies:
+    - core/common

--- a/roles/nfs/upgrade/tasks/apt/install.yml
+++ b/roles/nfs/upgrade/tasks/apt/install.yml
@@ -1,0 +1,14 @@
+---
+- name: install| Upgrade GPFS nfs packages
+  package:
+   name: "{{ scale_install_all_packages }}"
+   state: latest
+  when: scale_install_repository_url is defined
+
+- name: install| Upgrade GPFS NFS deb
+  apt:
+   deb: "{{ item }}"
+   state: latest
+  when: scale_install_repository_url is not defined
+  with_items:
+  - "{{ scale_install_all_packages }}"

--- a/roles/nfs/upgrade/tasks/install.yml
+++ b/roles/nfs/upgrade/tasks/install.yml
@@ -1,0 +1,69 @@
+---
+
+# Install or update RPMs
+# Ensure that installation method was chosen during previous role
+- block:
+  - name: upgrade | Check for repository installation method
+    set_fact:
+     scale_installmethod: repository
+    when:
+    - scale_install_repository_url is defined
+
+  - name: upgrade | Check for localpkg installation method
+    set_fact:
+     scale_installmethod: local_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is undefined
+    - scale_install_localpkg_path is defined
+
+  - name: upgrade | Check for remotepkg installation method
+    set_fact:
+     scale_installmethod: remote_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is defined
+
+  - name: upgrade | Check for directory package installation method
+    set_fact:
+      scale_installmethod: dir_pkg
+    when:
+      - scale_install_repository_url is undefined
+      - scale_install_remotepkg_path is undefined
+      - scale_install_localpkg_path is undefined
+      - scale_install_directory_pkg_path is defined
+
+  - name: upgrade | Check installation method
+    assert:
+     that: scale_installmethod is defined
+     msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#Run chosen installation method to get list of RPMs
+- name: upgrade | Initialize list of packages
+  set_fact:
+   scale_install_all_packages: []
+
+- name: upgrade | Set the extracted package directory path
+  set_fact:
+    nfs_extracted_path: "{{ scale_extracted_path }}"
+
+- name: upgrade | Stat extracted packages directory
+  stat:
+    path: "{{ nfs_extracted_path }}"
+  register: scale_extracted_gpfs_dir
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+  #- meta: flush_handlers
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/nfs/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/nfs/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,237 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS GUI
+#
+
+# Find nfs rpms
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.smb*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS SMB  package found {{ gpfs_path_url }}gpfs.smb*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha_*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ gpfs_path_url }}gpfs.nfs-ganesha*"
+  
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ gpfs_path_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-utils (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha-utils*
+    register: scale_install_gpfs_nfs_utils
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_utils.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-utils) package found {{ gpfs_path_url }}gpfs.nfs-ganesha-utils*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-gpfs (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha-gpfs*
+    register: scale_install_gpfs_nfs_gpfs
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_gpfs.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-gpfs)  found {{ gpfs_path_url }}gpfs.nfs-ganesha-gpfs*"
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-doc (gpfs.nfs-ganesha-doc) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha-doc*
+    register: scale_install_gpfs_nfs_doc
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-doc) package
+    assert:
+     that: scale_install_gpfs_nfs_doc.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-doc) package found {{ gpfs_path_url }}gpfs.nfs-ganesha-doc*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.python-nfs-ganesha (gpfs.python-nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.python-nfs-ganesha*
+    register: scale_install_gpfs_nfs_python
+
+  - name: upgrade | Check valid GPFS (gpfs.python-nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_python.matched > 0
+     msg: "No GPFS utils (gpfs.python-nfs-ganesha) package found {{ gpfs_path_url }}gpfs.python-nfs-ganesha*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.pm-ganesha (gpfs.pm-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.pm-ganesha*
+    register: scale_install_gpfs_nfs_pm
+
+  - name: upgrade | Check valid GPFS (gpfs.pm-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_pm.matched > 0
+     msg: "No GPFS utils (gpfs.pm-ganesha) package found {{ gpfs_path_url }}gpfs.pm-ganesha*"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.nfs-ganesha-debuginfo*
+    register: scale_install_gpfs_nfs_ganesha_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-debuginfo) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha_debuginfo.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha-debuginfo) package found {{ gpfs_path_url }}gpfs.nfs-ganesha-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_python.files }}"
+  - "{{ scale_install_gpfs_nfs_doc.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_pm.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha_debuginfo.files }}"
+
+  - name: upgrade | remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution
+
+- debug:
+        msg: "{{ scale_install_all_packages }}"

--- a/roles/nfs/upgrade/tasks/install_local_pkg.yml
+++ b/roles/nfs/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,321 @@
+---
+# Local package installation method
+- block:  ## run_once: true
+  - name: upgrade | Stat local installation package
+    stat:
+     path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
+    register: scale_install_localpkg
+
+  - name: upgrade | Check local installation package
+    assert:
+     that: scale_install_localpkg.stat.exists
+     msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+
+
+# Optionally, verify package checksum
+
+  - name: upgrade | Stat checksum file
+    stat:
+     path: "{{ scale_install_localpkg_path }}.md5"
+    register: scale_install_md5_file
+
+  - block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      set_fact:
+       scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+    - name: upgrade | Compare checksums
+      assert:
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+       msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+
+    when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+# Copy installation package
+
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path:  "{{ nfs_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+  - name: upgrade | Stat temporary directory
+    stat:
+     path: "{{ scale_install_localpkg_tmpdir_path }}"
+    register: scale_install_localpkg_tmpdir
+
+  - name: upgrade | Check temporary directory
+    assert:
+     that:
+     - scale_install_localpkg_tmpdir.stat.exists
+     - scale_install_localpkg_tmpdir.stat.isdir
+     msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+  - name: upgrade | Copy installation package to node
+    copy:
+     src: "{{ scale_install_localpkg_path }}"
+     dest: "{{ scale_install_localpkg_tmpdir_path }}"
+     mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+# Extract installation package
+
+- name: upgrade | Extract installation package
+  vars:
+   localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+   creates:  "{{ nfs_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path:  "{{ nfs_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+   that:
+   - scale_install_gpfs_rpmdir.stat.exists
+   - scale_install_gpfs_rpmdir.stat.isdir
+   msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+
+# Delete installation package
+
+- name: upgrade | Delete installation package from node
+  file:
+   path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+   state: absent
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version != '20'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version >= '15'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version != '20'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+
+# Find nfs rpms
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha_*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_sles_distribution or ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-utils (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-utils*
+    register: scale_install_gpfs_nfs_utils
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_utils.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-utils) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-utils*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-gpfs (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-gpfs*
+    register: scale_install_gpfs_nfs_gpfs
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_gpfs.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-gpfs)  found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-gpfs*"
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-doc (gpfs.nfs-ganesha-doc) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-doc*
+    register: scale_install_gpfs_nfs_doc
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-doc) package
+    assert:
+     that: scale_install_gpfs_nfs_doc.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-doc) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-doc*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.python-nfs-ganesha (gpfs.python-nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.python-nfs-ganesha*
+    register: scale_install_gpfs_nfs_python
+
+  - name: upgrade | Check valid GPFS (gpfs.python-nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_python.matched > 0
+     msg: "No GPFS utils (gpfs.python-nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.python-nfs-ganesha*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.pm-ganesha (gpfs.pm-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_zimon_url }}"
+     patterns: gpfs.pm-ganesha*
+    register: scale_install_gpfs_nfs_pm
+
+  - name: upgrade | Check valid GPFS (gpfs.pm-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_pm.matched > 0
+     msg: "No GPFS utils (gpfs.pm-ganesha) package found {{ nfs_extracted_path }}/{{ scale_zimon_url }}gpfs.pm-ganesha*"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-debuginfo*
+    register: scale_install_gpfs_nfs_ganesha_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-debuginfo) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha_debuginfo.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha-debuginfo) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_python.files }}"
+  - "{{ scale_install_gpfs_nfs_doc.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_pm.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha_debuginfo.files }}"
+
+  - name: remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution

--- a/roles/nfs/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/nfs/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,312 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ nfs_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: "{{ nfs_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ nfs_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha_*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha*
+    register: scale_install_gpfs_nfs_ganesha
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha*"
+
+  - name: upgrade | Add GPFS package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    when: scale_install_gpfs_nfs_ganesha.files is defined
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-utils (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-utils*
+    register: scale_install_gpfs_nfs_utils
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_utils.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-utils) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-utils*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-gpfs (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-gpfs*
+    register: scale_install_gpfs_nfs_gpfs
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_gpfs.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-gpfs)  found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-gpfs*"
+
+- block:
+  - name: upgrade | Find gpfs.nfs-ganesha-doc (gpfs.nfs-ganesha-doc) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-doc*
+    register: scale_install_gpfs_nfs_doc
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-doc) package
+    assert:
+     that: scale_install_gpfs_nfs_doc.matched > 0
+     msg: "No GPFS utils (gpfs.nfs-ganesha-doc) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-doc*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.python-nfs-ganesha (gpfs.python-nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.python-nfs-ganesha*
+    register: scale_install_gpfs_nfs_python
+
+  - name: upgrade | Check valid GPFS (gpfs.python-nfs-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_python.matched > 0
+     msg: "No GPFS utils (gpfs.python-nfs-ganesha) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.python-nfs-ganesha*"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- block:
+  - name: upgrade | Find gpfs.pm-ganesha (gpfs.pm-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_zimon_url }}"
+     patterns: gpfs.pm-ganesha*
+    register: scale_install_gpfs_nfs_pm
+
+  - name: upgrade | Check valid GPFS (gpfs.pm-ganesha) package
+    assert:
+     that: scale_install_gpfs_nfs_pm.matched > 0
+     msg: "No GPFS utils (gpfs.pm-ganesha) package found {{ nfs_extracted_path }}/{{ scale_zimon_url }}gpfs.pm-ganesha*"
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.nfs-ganesha (gpfs.nfs-ganesha) package
+    find:
+     paths:  "{{ nfs_extracted_path }}/{{ scale_nfs_url }}"
+     patterns: gpfs.nfs-ganesha-debuginfo*
+    register: scale_install_gpfs_nfs_ganesha_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.nfs-ganesha-debuginfo) package
+    assert:
+     that: scale_install_gpfs_nfs_ganesha_debuginfo.matched > 0
+     msg: "No GPFS nfs ganesha(gpfs.nfs-ganesha-debuginfo) package found {{ nfs_extracted_path }}/{{ scale_nfs_url }}gpfs.nfs-ganesha-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_python.files }}"
+  - "{{ scale_install_gpfs_nfs_doc.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Add GPFS package to list
+  vars:
+   current_package: "{{ item.path }}"
+  set_fact:
+   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+  - "{{ scale_install_gpfs_nfs_pm.files }}"
+
+- block:
+  - name: initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_nfs_ganesha_debuginfo.files }}"
+
+  - name: remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution

--- a/roles/nfs/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/nfs/upgrade/tasks/install_remote_pkg.yml
@@ -84,12 +84,22 @@
 - name: upgrade | nfs path
   set_fact:
    scale_nfs_url: 'ganesha_debs/ubuntu16/'
-  when: ansible_distribution in scale_ubuntu_distribution
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version != '20'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
 
 - name: upgrade | nfs path
   set_fact:
    scale_nfs_url: 'ganesha_rpms/sles12/'
-  when: ansible_distribution in scale_sles_distribution
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version >= '15'
 
 - name: upgrade | zimon path
   set_fact:
@@ -103,11 +113,6 @@
 
 - name: upgrade | zimon path
   set_fact:
-   scale_zimon_url: 'zimon_debs/ubuntu16/'
-  when: ansible_distribution in scale_ubuntu_distribution
-
-- name: upgrade | zimon path
-  set_fact:
    scale_zimon_url: 'zimon_rpms/sles12/'
   when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
 
@@ -115,6 +120,16 @@
   set_fact:
    scale_zimon_url: 'zimon_rpms/sles15/'
   when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version != '20'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
 
 - name: upgrade | smb path
   set_fact:
@@ -149,9 +164,9 @@
      current_package: "{{ item.path }}"
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
-    when: scale_install_gpfs_nfs_ganesha.files is defined
     with_items:
     - "{{ scale_install_gpfs_smb.files }}"
+
   when: ansible_distribution in scale_ubuntu_distribution
 
 - block:  ## when: host is defined as a protocol node
@@ -306,7 +321,7 @@
     with_items:
     - "{{ scale_install_gpfs_nfs_ganesha_debuginfo.files }}"
 
-  - name: remove debuginfo from packages
+  - name: upgrade | remove debuginfo from packages
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
   when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution

--- a/roles/nfs/upgrade/tasks/install_repository.yml
+++ b/roles/nfs/upgrade/tasks/install_repository.yml
@@ -1,0 +1,160 @@
+---
+- name: Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | nfs path
+  set_fact:
+   scale_nfs_url: 'ganesha_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version >= '15'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version != '20'
+
+- name: upgrade | zimon path
+  set_fact:
+   scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- name: install|configure nfs YUM repository
+  yum_repository:
+    name: spectrum-scale-nfs-rpms
+    description: IBM Spectrum Scale (NFS RPMS)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_nfs_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure nfs APT repository
+  apt_repository:
+    filename: spectrum-scale-nfs-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}{{ scale_nfs_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (NFS debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure nfs zypper repository
+  zypper_repository:
+    name: spectrum-scale-nfs-rpms
+    repo: "{{ scale_install_repository_url }}{{ scale_nfs_url }}"
+    runrefresh: yes
+    state: present
+    disable_gpg_check: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+- name: install|configure pm-ganesha YUM repository
+  yum_repository:
+    name: spectrum-scale-pm-ganesha-rpms
+    description: IBM Spectrum Scale (PM-ganesha RPMS)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure pm-ganesha APT repository
+  apt_repository:
+    filename: spectrum-scale-pm-ganesha-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}{{ scale_zimon_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (PM-ganesha debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure pm-ganesha zypper repository
+  zypper_repository:
+    name: spectrum-scale-pm-ganesha-rpms
+    repo: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
+    runrefresh: yes
+    state: present
+    disable_gpg_check: yes
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Add GPFS nfs packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_nfs_rpms }}"
+  when: ansible_distribution in scale_rhel_distribution or
+        ansible_distribution in scale_sles_distribution
+
+- name: upgrade | Add GPFS nfs packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_nfs_debs }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Add GPFS pm-ganesha packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_pm_package }}"

--- a/roles/nfs/upgrade/tasks/main.yml
+++ b/roles/nfs/upgrade/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: install.yml
+  tags: install

--- a/roles/nfs/upgrade/tasks/yum/install.yml
+++ b/roles/nfs/upgrade/tasks/yum/install.yml
@@ -1,0 +1,15 @@
+---
+- name: upgrade | Initialize
+  set_fact:
+    disable_gpgcheck: "no"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+    disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS nfs packages
+  yum:
+   name: "{{ scale_install_all_packages }}"
+   state: latest
+   disable_gpg_check: "{{ disable_gpgcheck }}"

--- a/roles/nfs/upgrade/tasks/zypper/install.yml
+++ b/roles/nfs/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,6 @@
+---
+- name: upgrade | Upgrade GPFS NFS packages
+  zypper:
+   name: "{{ scale_install_all_packages }}"
+   state: latest
+   disable_gpg_check: no

--- a/roles/nfs/upgrade/vars/main.yml
+++ b/roles/nfs/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (GPFS) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Default scale extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/scale_ece/upgrade/defaults/main.yml
+++ b/roles/scale_ece/upgrade/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+scale_gnr_packages:
+- gpfs.gnr
+- gpfs.gnr.base
+- gpfs.gnr.support-scaleout
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+scale_install_localpkg_tmpdir_path: /tmp

--- a/roles/scale_ece/upgrade/handlers/main.yml
+++ b/roles/scale_ece/upgrade/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-# Handlers for the common role for IBM Spectrum Scale (GPFS) cluster role
 # handlers file for node
 - name: yum-clean-metadata
   command: yum clean metadata

--- a/roles/scale_ece/upgrade/meta/main.yml
+++ b/roles/scale_ece/upgrade/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: scale_ece
+  author: IBM Corporation
+  description: Role for configuring IBM Spectrum Scale (GPFS) Erasure Code Edition configuration role
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+   - core/common

--- a/roles/scale_ece/upgrade/tasks/install.yml
+++ b/roles/scale_ece/upgrade/tasks/install.yml
@@ -1,0 +1,63 @@
+---
+# Install or update RPMs
+# Ensure that installation method was chosen during previous role
+- block:
+  - name: upgrade | Check for repository installation method
+    set_fact:
+     scale_installmethod: repository
+    when:
+    - scale_install_repository_url is defined
+
+  - name: upgrade | Check for localpkg installation method
+    set_fact:
+     scale_installmethod: local_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is undefined
+    - scale_install_localpkg_path is defined
+
+  - name: upgrade | Check for remotepkg installation method
+    set_fact:
+     scale_installmethod: remote_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is defined
+  
+  - name: upgrade | Check for directory package installation method
+    set_fact:
+      scale_installmethod: dir_pkg
+    when:
+      - scale_install_repository_url is undefined
+      - scale_install_remotepkg_path is undefined
+      - scale_install_localpkg_path is undefined
+      - scale_install_directory_pkg_path is defined
+ 
+  - name: upgrade | Check installation method
+    assert:
+     that: scale_installmethod is defined
+     msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+# Run chosen installation method to get list of RPMs
+
+- name: upgrade | Initialize list of packages
+  set_fact:
+   scale_install_all_packages: []
+
+- name: upgrade | Set the extracted package directory path
+  set_fact:
+    gnr_extracted_path: "{{ scale_extracted_path }}"
+
+- name: upgrade | Stat extracted packages directory
+  stat:
+    path: "{{ gnr_extracted_path }}"
+  register: scale_extracted_gpfs_dir
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+

--- a/roles/scale_ece/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/scale_ece/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,69 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.gnr (gpfs.gnr) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.gnr*
+    register: scale_install_gpfs_gnr
+
+  - name: upgrade | Check valid GPFS (gpfs.gnr) package
+    assert:
+     that: scale_install_gpfs_gnr.matched > 0
+     msg: "No GPFS gnr (gpfs.gnr) package found {{ gpfs_path_url }}gpfs.gnr*"
+
+  - name: upgrade | Add GPFS gnr package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_gnr.files }}"

--- a/roles/scale_ece/upgrade/tasks/install_local_pkg.yml
+++ b/roles/scale_ece/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,135 @@
+---
+# Local package installation method
+- block:  ## run_once: true
+  - name: upgrade | Stat local installation package
+    stat:
+     path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
+    register: scale_install_localpkg
+
+  - name: upgrade | Check local installation package
+    assert:
+     that: scale_install_localpkg.stat.exists
+     msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+
+# Optionally, verify package checksum
+
+#
+  - name: upgrade | Stat checksum file
+    stat:
+     path: "{{ scale_install_localpkg_path }}.md5"
+    register: scale_install_md5_file
+
+  - block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      set_fact:
+       scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+    - name: upgrade | Compare checksums
+      assert:
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+       msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+    when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+#
+
+# Copy installation package
+
+#
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path: "{{ gnr_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+  - name: upgrade | Stat temporary directory
+    stat:
+     path: "{{ scale_install_localpkg_tmpdir_path }}"
+    register: scale_install_localpkg_tmpdir
+
+  - name: upgrade | Check temporary directory
+    assert:
+     that:
+     - scale_install_localpkg_tmpdir.stat.exists
+     - scale_install_localpkg_tmpdir.stat.isdir
+     msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+  - name: upgrade | Copy installation package to node
+    copy:
+     src: "{{ scale_install_localpkg_path }}"
+     dest: "{{ scale_install_localpkg_tmpdir_path }}"
+     mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+#
+
+# Extract installation package
+
+#
+- name: upgrade | Extract installation package
+  vars:
+   localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+   creates: "{{ gnr_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path: "{{ gnr_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+   that:
+   - scale_install_gpfs_rpmdir.stat.exists
+   - scale_install_gpfs_rpmdir.stat.isdir
+   msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+
+# Delete installation package
+
+#
+- name: upgrade | Delete installation package from node
+  file:
+   path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+   state: absent
+
+- name: upgrade | gnr path
+  set_fact:
+   scale_gnr_url: 'gpfs_rpms/'
+  when: ansible_distribution in scale_rhel_distribution
+
+#
+
+# Find gnr rpms
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.gnr (gpfs.gnr) package
+    find:
+     paths:  "{{ gnr_extracted_path }}/{{ scale_gnr_url }}"
+     patterns: gpfs.gnr*
+    register: scale_install_gpfs_gnr
+
+  - name: upgrade | Check valid GPFS (gpfs.gnr) package
+    assert:
+     that: scale_install_gpfs_gnr.matched > 0
+     msg: "No GPFS gnr (gpfs.gnr) package found {{ gnr_extracted_path }}/{{ scale_gnr_url }}gpfs.gnr*"
+
+  - name: upgrade | Add GPFS gnr package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_gnr.files }}"

--- a/roles/scale_ece/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/scale_ece/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,97 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ gnr_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates:  "{{ gnr_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ gnr_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+- name: upgrade | gnr path
+  set_fact:
+   scale_gnr_url: 'gpfs_rpms/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.gnr (gpfs.gnr) package
+    find:
+     paths:  "{{ gnr_extracted_path }}/{{ scale_gnr_url }}"
+     patterns: gpfs.gnr*
+    register: scale_install_gpfs_gnr
+
+  - name: upgrade | Check valid GPFS (gpfs.gnr) package
+    assert:
+     that: scale_install_gpfs_gnr.matched > 0
+     msg: "No GPFS gnr (gpfs.gnr) package found {{ gnr_extracted_path }}/{{ scale_gnr_url }}gpfs.gnr*"
+
+  - name: upgrade | Add GPFS gnr package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_gnr.files }}"

--- a/roles/scale_ece/upgrade/tasks/install_repository.yml
+++ b/roles/scale_ece/upgrade/tasks/install_repository.yml
@@ -1,0 +1,34 @@
+---
+- name: Initialize
+  set_fact:
+   scale_gnr_url: ""
+   gpgcheck: "yes"
+
+- name: Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | gnr path
+  set_fact:
+   scale_gnr_url: 'gpfs_rpms/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: upgrade | Configure gnr YUM repository
+  yum_repository:
+    name: spectrum-scale-gnr
+    description: IBM Spectrum Scale (gnr)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_gnr_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Add GPFS gnr packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_gnr_packages }}"

--- a/roles/scale_ece/upgrade/tasks/main.yml
+++ b/roles/scale_ece/upgrade/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# tasks file for install
+- import_tasks: install.yml
+  tags: install

--- a/roles/scale_ece/upgrade/tasks/yum/install.yml
+++ b/roles/scale_ece/upgrade/tasks/yum/install.yml
@@ -1,0 +1,15 @@
+---
+- name: Initialize
+  set_fact:
+    disable_gpgcheck: "no"
+
+- name: Disable gpg check
+  set_fact:
+    disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS gnr packages
+  yum:
+   name: "{{ scale_install_all_packages }}"
+   state: present
+   disable_gpg_check: "{{ disable_gpgcheck }}"

--- a/roles/scale_ece/upgrade/vars/main.yml
+++ b/roles/scale_ece/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the Erasure code Edition node role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Default scale extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/scale_fileauditlogging/upgrade/defaults/main.yml
+++ b/roles/scale_fileauditlogging/upgrade/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) (audit logging) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale file audit logging repository
+## (copy the contents of /usr/lpp/mmfs/.../gpfs_rpms/rhel7 to build your repository)
+# scale_install_repository_url: http://infraserv/
+
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## List of packages to install for file audit logging
+scale_auditlogging_packages:
+  - gpfs.librdkafka*
+  - gpfs.java
+
+## Flag to enable fileauditlogging
+scale_fileauditlogging_enable: true
+
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv

--- a/roles/scale_fileauditlogging/upgrade/handlers/main.yml
+++ b/roles/scale_fileauditlogging/upgrade/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for install

--- a/roles/scale_fileauditlogging/upgrade/meta/main.yml
+++ b/roles/scale_fileauditlogging/upgrade/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: fileauditlogging
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) fileauditlogging
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+  - core/common

--- a/roles/scale_fileauditlogging/upgrade/tasks/apt/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/apt/install.yml
@@ -1,0 +1,19 @@
+---
+
+#
+# Install or update RPMs
+#
+- name: upgrade | Upgrade GPFS file audit logging packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: present
+  when: scale_install_repository_url is defined
+
+- block:
+    - name: upgrade | Upgrade GPFS file audit logging packages
+      apt:
+        deb: "{{ item }}"
+        state: present
+      with_items:
+        - "{{ scale_install_all_packages }}"
+  when: scale_install_repository_url is not defined

--- a/roles/scale_fileauditlogging/upgrade/tasks/apt/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/apt/install.yml
@@ -6,7 +6,7 @@
 - name: upgrade | Upgrade GPFS file audit logging packages
   package:
     name: "{{ scale_install_all_packages }}"
-    state: present
+    state: latest
   when: scale_install_repository_url is defined
 
 - block:

--- a/roles/scale_fileauditlogging/upgrade/tasks/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install.yml
@@ -1,0 +1,66 @@
+---
+# Install or update RPMs
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - name: upgrade | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_repository_url is defined
+        - scale_install_localpkg_path is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+
+    - name: upgrade | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: upgrade | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: upgrade | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of RPMs
+#
+- name: upgrade | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- meta: flush_handlers
+
+#
+# Install or update RPMs
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,78 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: upgrade | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ gpfs_path_url }}"
+        patterns: gpfs.librdkafka*.rpm
+      register: scale_install_gpfs_fal
+
+    - name: upgrade | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ gpfs_path_url }}gpfs.librdkafka*.rpm
+
+    - name: upgrade | Add GPFS file audit logging packages to list
+      vars:
+        current_package: "{{ gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_local_pkg.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,142 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
+      register: scale_install_localpkg
+
+    - name: upgrade | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: upgrade | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: upgrade | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: upgrade | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: upgrade | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: upgrade | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: upgrade | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+#todo wrong
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: upgrade | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_fal_url }}"
+        patterns: gpfs.librdkafka*
+      register: scale_install_gpfs_fal
+
+    - name: upgrade | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ scale_extracted_path }}/{{ scale_fal_url }}gpfs.librdkafka*
+
+    - name: upgrade | Add GPFS file audit logging packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_fal_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,130 @@
+
+---
+
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+
+
+# Optionally, verify package checksum
+
+
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+
+
+# Extract installation package
+
+
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+  register: scale_install_gpfs_rpmdir
+
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: /usr/lpp/mmfs/{{ scale_version }}/gpfs_rpms
+  register: scale_install_gpfs_rpmdir
+
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+#
+# Find file audit logging package
+#
+- block:
+    #
+    # Find GPFS librdkafka
+    #
+    - name: upgrade | Find gpfs.librdkafka (gpfs.librdkafka) package
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_fal_url }}"
+        patterns: gpfs.librdkafka*.rpm
+      register: scale_install_gpfs_fal
+
+    - name: upgrade | Check valid GPFS (gpfs.librdkafka) package
+      assert:
+        that: scale_install_gpfs_fal.matched > 0
+        msg: >-
+          No GPFS auditlogin librakafka(gpfs.librdkafka) package found
+          {{ scale_extracted_path }}/{{ scale_fal_url }}gpfs.librdkafka*.rpm
+
+    - name: upgrade | Add GPFS file audit logging packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_fal_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_fal.files.0.path | basename }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
@@ -7,6 +7,7 @@
 - name: upgrade | Initialize
   set_fact:
    scale_fal_url: ""
+   package_installed: false
 
 - name: upgrade | file audit logging path
   set_fact:
@@ -31,6 +32,14 @@
   set_fact:
    gpgcheck: "no"
   when: scale_version < '5.0.4.0'
+
+- name: install | Get license package
+  yum:
+    list: gpfs.kafka.*
+  register: gpfskafka_installed
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+
 
 - name: upgrade | Configure GPFS Java YUM repository
   yum_repository:
@@ -109,6 +118,21 @@
     state: present
   when:
     - ansible_pkg_mgr == 'zypper'
+
+
+- name: update | Check if gpfs kafka installed
+  set_fact:
+    package_installed: true
+  when:
+     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+     - "'installed' in gpfskafka_installed.results | map(attribute='yumstate') | list"
+
+- name: upgrade | Add GPFS file audit logging packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - gpfs.kafka*
+  when: (package_installed | bool)
 
 #
 # Add FAL packages

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
@@ -1,0 +1,121 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: upgrade | Initialize
+  set_fact:
+   scale_fal_url: ""
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_rhel_distribution
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | file audit logging path
+  set_fact:
+    scale_fal_url: 'gpfs_rpms/rhel/'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: upgrade | Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Configure GPFS Java YUM repository
+  yum_repository:
+    name: spectrum-scale-gpfs-java
+    description: IBM Spectrum Scale (GPFS Java)
+    baseurl: "{{ scale_install_repository_url }}gpfs_rpms/"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+#
+# Configure apt repository
+#
+- name: upgrade | Configure GPFS Java APT repository
+  apt_repository:
+    filename: spectrum-scale-gpfs-java-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}gpfs_debs/ ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (gpfs java debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+#
+# Configure zypper repository
+#
+- name: upgrade | Configure GPFS Java repository
+  zypper_repository:
+    name: spectrum-scale-gpfs-java
+    description: IBM Spectrum Scale (GPFS java)
+    repo: "{{ scale_install_repository_url }}gpfs_rpms/"
+    disable_gpg_check: yes
+    state: present
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+ 
+- name: upgrade | Configure fal YUM repository
+  yum_repository:
+    name: spectrum-scale-fal
+    description: IBM Spectrum Scale (FAL)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_fal_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure fal APT repository
+  apt_repository:
+    filename: spectrum-scale-fal-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}{{ scale_fal_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (FAL debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure fal repository
+  zypper_repository:
+    name: spectrum-scale-fal-sles
+    description: IBM Spectrum Scale (FAL)
+    repo: "{{ scale_install_repository_url }}{{ scale_fal_url }}"
+    disable_gpg_check: no
+    state: present
+  when:
+    - ansible_pkg_mgr == 'zypper'
+
+#
+# Add FAL packages
+#
+- name: upgrade | Add GPFS file audit logging packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_auditlogging_packages }}"
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/install_repository.yml
@@ -33,7 +33,7 @@
    gpgcheck: "no"
   when: scale_version < '5.0.4.0'
 
-- name: install | Get license package
+- name: upgrade | Check if gpfs kafka installed
   yum:
     list: gpfs.kafka.*
   register: gpfskafka_installed
@@ -120,12 +120,29 @@
     - ansible_pkg_mgr == 'zypper'
 
 
-- name: update | Check if gpfs kafka installed
+- name: upgrade | Set if gpfs kafka installed
   set_fact:
     package_installed: true
   when:
      - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
      - "'installed' in gpfskafka_installed.results | map(attribute='yumstate') | list"
+
+- name: upgrade | Check if gpfs kafka installed
+  shell: dpkg -l | grep gpfs.kafka | awk "{print $1}" |  grep ii
+  register: scale_kafka_status
+  failed_when: no
+  changed_when: no
+  args:
+    warn: false
+  when:
+    - ansible_pkg_mgr == 'apt'
+
+- name: upgrade | Set if gpfs kafka installed
+  set_fact:
+    package_installed: true
+  when:
+     - ansible_pkg_mgr == 'apt'
+     - scale_kafka_status.rc == 0
 
 - name: upgrade | Add GPFS file audit logging packages to list
   set_fact:

--- a/roles/scale_fileauditlogging/upgrade/tasks/main.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for install
+- import_tasks: install.yml
+  tags: install
+  when: (scale_fileauditlogging_enable | bool)

--- a/roles/scale_fileauditlogging/upgrade/tasks/yum/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/yum/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update RPMs
+#
+- name: Initialize
+  set_fact:
+    disable_gpgcheck: "no"
+
+- name: Disable gpg check
+  set_fact:
+    disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS file audit logging packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: present
+    disable_gpg_check: "{{ disable_gpgcheck }}"

--- a/roles/scale_fileauditlogging/upgrade/tasks/zypper/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/zypper/install.yml
@@ -3,5 +3,5 @@
     - name: upgrade | Upgrade GPFS file audit logging packages
       zypper:
           name: "{{ scale_install_all_packages }}"
-          state: present
+          state: latest
           disable_gpg_check: no

--- a/roles/scale_fileauditlogging/upgrade/tasks/zypper/install.yml
+++ b/roles/scale_fileauditlogging/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,7 @@
+---
+- block:
+    - name: upgrade | Upgrade GPFS file audit logging packages
+      zypper:
+          name: "{{ scale_install_all_packages }}"
+          state: present
+          disable_gpg_check: no

--- a/roles/scale_fileauditlogging/upgrade/tests/inventory
+++ b/roles/scale_fileauditlogging/upgrade/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/scale_fileauditlogging/upgrade/tests/test.yml
+++ b/roles/scale_fileauditlogging/upgrade/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - install

--- a/roles/scale_fileauditlogging/upgrade/vars/main.yml
+++ b/roles/scale_fileauditlogging/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (File audit logging) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/scale_hpt/upgrade/defaults/main.yml
+++ b/roles/scale_hpt/upgrade/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) AFM COS (HPT) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale GPFS YUM repository
+## (copy the contents of /usr/lpp/mmfs/.../gpfs_rpms/ to build your repository)
+# scale_install_repository_url: http://infraserv/
+
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## List of RPMs to install on GUI nodes
+scale_hpt_packages:
+  - gpfs.afm.cos
+
+## you'll likely want to define per-node roles in your inventory
+scale_install_package: true
+
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv

--- a/roles/scale_hpt/upgrade/meta/main.yml
+++ b/roles/scale_hpt/upgrade/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: scale_hpt
+  author: IBM Corporation
+  description: Role for installing IBM Spectrum Scale (GPFS) AFM COS package
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.9
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+  - core/common

--- a/roles/scale_hpt/upgrade/tasks/apt/install.yml
+++ b/roles/scale_hpt/upgrade/tasks/apt/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update packages
+#
+- block:
+    - name: upgrade | Upgrade GPFS HPT packages
+      package:
+        name: "{{ scale_install_all_packages }}"
+        state: present
+      when: scale_install_repository_url is defined
+
+    - name: upgrade | Upgrade GPFS HPT packages
+      apt:
+        deb: "{{ item }}"
+        state: latest
+      with_items:
+        - "{{ scale_install_all_packages }}"
+      when: scale_install_repository_url is not defined

--- a/roles/scale_hpt/upgrade/tasks/apt/install.yml
+++ b/roles/scale_hpt/upgrade/tasks/apt/install.yml
@@ -6,7 +6,7 @@
     - name: upgrade | Upgrade GPFS HPT packages
       package:
         name: "{{ scale_install_all_packages }}"
-        state: present
+        state: latest
       when: scale_install_repository_url is defined
 
     - name: upgrade | Upgrade GPFS HPT packages

--- a/roles/scale_hpt/upgrade/tasks/install.yml
+++ b/roles/scale_hpt/upgrade/tasks/install.yml
@@ -1,0 +1,62 @@
+---
+# Install or update packages
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - name: upgrade | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_repository_url is defined
+
+    - name: upgrade | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: upgrade | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: upgrade | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of packages
+#
+- name: upgrade | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- meta: flush_handlers
+
+#
+# Install or update packages
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/scale_hpt/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/scale_hpt/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,75 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    scale_gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS afm cos
+#
+- block:
+    - name: upgrade | Find GPFS HPT (gpfs.afm.cos) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.afm.cos*
+      register: scale_install_gpfs_hpt
+
+    - name: upgrade | Check valid GPFS HPT (gpfs.afm.cos) package
+      assert:
+        that: scale_install_gpfs_hpt.matched > 0
+        msg: >-
+          No GPFS HPT (gpfs.afm.cos) package found:
+          "{{ scale_gpfs_path_url }}/gpfs_packages/gpfs.afm.cos*"
+
+    - name: upgrade | Add GPFS HPT packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_hpt.files.0.path | basename }}"
+
+  when: scale_install_package | bool

--- a/roles/scale_hpt/upgrade/tasks/install_local_pkg.yml
+++ b/roles/scale_hpt/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,125 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
+      register: scale_install_localpkg
+
+    - name: upgrade | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: upgrade | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: upgrade | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: upgrade | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: upgrade | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: upgrade | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: upgrade | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+#
+# Find GPFS AFM COS(HPT)
+#
+- block:
+    - name: upgrade | Find GPFS HPT (gpfs.afm.cos) packages
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.afm.cos*
+      register: scale_install_gpfs_hpt
+
+    - name: upgrade | Check valid GPFS HPT (gpfs.afm.cos) packages
+      assert:
+        that: scale_install_gpfs_hpt.matched > 0
+        msg: >-
+          No GPFS HPT (gpfs.afm.cos) packages found:
+          "{{ scale_gpfs_path_url }}/gpfs.afm.cos*"
+
+    - name: upgrade | Add GPFS HPT packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_hpt.files.0.path | basename }}"
+
+  when: scale_install_package | bool

--- a/roles/scale_hpt/upgrade/tasks/install_repository.yml
+++ b/roles/scale_hpt/upgrade/tasks/install_repository.yml
@@ -1,0 +1,63 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: upgrade | Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Configure HPT YUM repository
+  yum_repository:
+    name: spectrum-scale-hpt
+    description: IBM Spectrum Scale (HPT)
+    baseurl: "{{ scale_install_repository_url }}gpfs_rpms/"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure HPT APT repository
+  apt_repository:
+    filename: spectrum-scale-hpt-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}gpfs_debs/ ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (HPT debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure HPT repository
+  zypper_repository:
+    name: spectrum-scale-hpt
+    description: IBM Spectrum Scale (HPT)
+    repo: "{{ scale_install_repository_url }}gpfs_rpms/"
+    disable_gpg_check: no
+    state: present
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+#
+# Add HPT RPMs
+#
+
+- name: upgrade | Add GPFS AFM COS package to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_hpt_packages }}"
+  when: scale_install_package | bool

--- a/roles/scale_hpt/upgrade/tasks/main.yml
+++ b/roles/scale_hpt/upgrade/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# Install IBM Spectrum Scale (GPFS) AFM COS (HPT) role
+
+- import_tasks: install.yml
+  tags: install
+  when: (scale_install_package | bool)

--- a/roles/scale_hpt/upgrade/tasks/yum/install.yml
+++ b/roles/scale_hpt/upgrade/tasks/yum/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update packages
+#
+- name: upgrade | Initialize
+  set_fact:
+    scale_disable_gpgcheck: "no"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+    scale_disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS HPT packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: latest
+    disable_gpg_check: "{{ scale_disable_gpgcheck }}"

--- a/roles/scale_hpt/upgrade/tasks/zypper/install.yml
+++ b/roles/scale_hpt/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,7 @@
+---
+- block:
+    - name: upgrade | Upgrade GPFS HPT packages
+      zypper:
+          name: "{{ scale_install_all_packages }}"
+          state: latest
+          disable_gpg_check: no

--- a/roles/scale_hpt/upgrade/vars/main.yml
+++ b/roles/scale_hpt/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (HPT) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/smb/upgrade/defaults/main.yml
+++ b/roles/smb/upgrade/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# Default variables for the IBM Spectrum Scale (SMB) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale YUM/apt/zypper repository
+#scale_install_smb_repository_rpms: http://<ip>/smb_rpms/
+#scale_install_smb_repository_debs: http://<ip>/smb_debs/
+#scale_install_smb_repository_rpms_sles: http://<ip>/smb_rpms/sles12/
+
+## List of NFS packages to install
+scale_smb_packages:
+- gpfs.smb
+
+## Temporary directory to copy installation package to
+## (local package installation method)
+scale_install_localpkg_tmpdir_path: /tmp
+
+## Flag to install smb debug package
+install_debuginfo: true

--- a/roles/smb/upgrade/handlers/main.yml
+++ b/roles/smb/upgrade/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-# Handlers for the common role for IBM Spectrum Scale (GPFS) cluster role
 # handlers file for node
 - name: yum-clean-metadata
   command: yum clean metadata

--- a/roles/smb/upgrade/meta/main.yml
+++ b/roles/smb/upgrade/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: nfs_node
+  author: IBM Corporation
+  description: Highly-customizable Ansible role for installing and configuring IBM Spectrum Scale (GPFS)
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+
+dependencies:
+    - core/common

--- a/roles/smb/upgrade/tasks/apt/install.yml
+++ b/roles/smb/upgrade/tasks/apt/install.yml
@@ -1,0 +1,15 @@
+---
+- name: Install GPFS smb packages
+  package:
+   name: "{{ scale_install_all_packages }}"
+   state: present
+  when: scale_install_repository_url is defined
+
+
+- name: upgrade | Upgrade GPFS SMB deb
+  apt:
+   deb: "{{ item }}"
+   state: latest
+  when: scale_install_repository_url is not defined
+  with_items:
+  - "{{ scale_install_all_packages }}"

--- a/roles/smb/upgrade/tasks/apt/install.yml
+++ b/roles/smb/upgrade/tasks/apt/install.yml
@@ -2,7 +2,7 @@
 - name: Install GPFS smb packages
   package:
    name: "{{ scale_install_all_packages }}"
-   state: present
+   state: latest
   when: scale_install_repository_url is defined
 
 

--- a/roles/smb/upgrade/tasks/install.yml
+++ b/roles/smb/upgrade/tasks/install.yml
@@ -1,0 +1,69 @@
+---
+# Install or update RPMs
+# Ensure that installation method was chosen during previous role
+- block:
+  - name: upgrade | Check for repository installation method
+    set_fact:
+     scale_installmethod: repository
+    when:
+    - scale_install_repository_url is defined
+
+  - name: upgrade | Check for localpkg installation method
+    set_fact:
+     scale_installmethod: local_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is undefined
+    - scale_install_localpkg_path is defined
+
+  - name: upgrade | Check for remotepkg installation method
+    set_fact:
+     scale_installmethod: remote_pkg
+    when:
+    - scale_install_repository_url is undefined
+    - scale_install_remotepkg_path is defined
+
+  - name: upgrade | Check for directory package installation method
+    set_fact:
+      scale_installmethod: dir_pkg
+    when:
+      - scale_install_repository_url is undefined
+      - scale_install_remotepkg_path is undefined
+      - scale_install_localpkg_path is undefined
+      - scale_install_directory_pkg_path is defined
+
+  - name: upgrade | Check installation method
+    assert:
+     that: scale_installmethod is defined
+     msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+# Run chosen installation method to get list of RPMs
+
+- name: upgrade | Initialize list of packages
+  set_fact:
+   scale_install_all_packages: []
+
+- name: upgrade | Set the extracted package directory path
+  set_fact:
+    smb_extracted_path: "{{ scale_extracted_path }}"
+
+- name: upgrade | Stat extracted packages directory
+  stat:
+    path: "{{ smb_extracted_path }}"
+  register: scale_extracted_gpfs_dir
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution
+

--- a/roles/smb/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/smb/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,107 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Set installation package path
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find GPFS SMB
+#
+# 
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.smb*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ gpfs_path_url }}gpfs.smb*"
+
+  - name: upgrade | Add GPFS smb package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb-debuginfo (gpfs.smb-debuginfo) package
+    find:
+     paths:  "{{ gpfs_path_url }}"
+     patterns: gpfs.smb-debuginfo*
+    register: scale_install_gpfs_smb_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.smb-debuginfo) package
+    assert:
+     that: scale_install_gpfs_smb_debuginfo.matched > 0
+     msg: "No GPFS smb (gpfs.smb-debuginfo) package found {{ gpfs_path_url }}gpfs.smb-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb_debuginfo.files }}"
+
+  - name: remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution
+
+- debug:
+   msg: "{{ scale_install_all_packages }}"

--- a/roles/smb/upgrade/tasks/install_local_pkg.yml
+++ b/roles/smb/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,220 @@
+---
+# Local package installation method
+- block:  ## run_once: true
+  - name: upgrade | Stat local installation package
+    stat:
+     path: "{{ scale_install_localpkg_path }}"
+     checksum_algorithm: md5
+    register: scale_install_localpkg
+
+  - name: upgrade | Check local installation package
+    assert:
+     that: scale_install_localpkg.stat.exists
+     msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+
+#
+
+# Optionally, verify package checksum
+
+#
+  - name: upgrade | Stat checksum file
+    stat:
+     path: "{{ scale_install_localpkg_path }}.md5"
+    register: scale_install_md5_file
+
+  - block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      set_fact:
+       scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+    - name: upgrade | Compare checksums
+      assert:
+       that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+       msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+
+    when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+#
+
+# Copy installation package
+
+#
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path: "{{ smb_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- block:  ## when: not scale_install_gpfs_rpmdir.stat.exists
+  - name: upgrade | Stat temporary directory
+    stat:
+     path: "{{ scale_install_localpkg_tmpdir_path }}"
+    register: scale_install_localpkg_tmpdir
+
+  - name: upgrade | Check temporary directory
+    assert:
+     that:
+     - scale_install_localpkg_tmpdir.stat.exists
+     - scale_install_localpkg_tmpdir.stat.isdir
+     msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+
+  - name: upgrade | Copy installation package to node
+    copy:
+     src: "{{ scale_install_localpkg_path }}"
+     dest: "{{ scale_install_localpkg_tmpdir_path }}"
+     mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+#
+
+# Extract installation package
+
+#
+- name: upgrade | Extract installation package
+  vars:
+   localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+   creates: "{{ smb_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+   path: "{{ smb_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+   that:
+   - scale_install_gpfs_rpmdir.stat.exists
+   - scale_install_gpfs_rpmdir.stat.isdir
+   msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+
+# Delete installation package
+
+#
+- name: upgrade | Delete installation package from node
+  file:
+   path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+   state: absent
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version >= '15'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+
+# Find smb rpms
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
+
+  - name: upgrade | Add GPFS smb package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
+
+  - name: upgrade | Add GPFS smb package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_ubuntu_distribution
+
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb-debuginfo (gpfs.smb-debuginfo) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-debuginfo*
+    register: scale_install_gpfs_smb_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.smb-debuginfo) package
+    assert:
+     that: scale_install_gpfs_smb_debuginfo.matched > 0
+     msg: "No GPFS smb (gpfs.smb-debuginfo) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb_debuginfo.files }}"
+
+  - name: remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution

--- a/roles/smb/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/smb/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,153 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ smb_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates:  "{{ smb_extracted_path }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ smb_extracted_path }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb*
+    register: scale_install_gpfs_smb
+
+  - name: upgrade | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
+
+  - name: upgrade | Add GPFS smb package to list
+    vars:
+     current_package:  "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: upgrade | Find gpfs.smb-debuginfo (gpfs.smb-debuginfo) package
+    find:
+     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-debuginfo*
+    register: scale_install_gpfs_smb_debuginfo
+
+  - name: upgrade | Check valid GPFS (gpfs.smb-debuginfo) package
+    assert:
+     that: scale_install_gpfs_smb_debuginfo.matched > 0
+     msg: "No GPFS smb (gpfs.smb-debuginfo) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb-debuginfo*"
+  when: ansible_distribution in scale_rhel_distribution
+
+- block:
+  - name: initialize
+    set_fact:
+     debuginfo_package: []
+
+  - name: upgrade | Add GPFS package to list
+    set_fact:
+     debuginfo_package: "{{ debuginfo_package + [ item.path ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb_debuginfo.files }}"
+
+  - name: remove debuginfo from packages
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages | difference(debuginfo_package)}}"
+  when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution

--- a/roles/smb/upgrade/tasks/install_repository.yml
+++ b/roles/smb/upgrade/tasks/install_repository.yml
@@ -1,0 +1,87 @@
+---
+- name: upgrade | Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version >= '15'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | smb path
+  set_fact:
+   scale_smb_url: 'smb_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version >= '20'
+
+- name: upgrade | Configure smb YUM repository
+  yum_repository:
+    name: spectrum-scale-smb
+    description: IBM Spectrum Scale (smb)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_smb_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure smb zypper repository
+  zypper_repository:
+    name: spectrum-scale-smb-rpms
+    repo: "{{ scale_install_repository_url }}{{ scale_smb_url }}"
+    runrefresh: yes
+    state: present
+    disable_gpg_check: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure smb APT repository
+  apt_repository:
+    filename: spectrum-scale-smb-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}{{ scale_smb_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (SMB debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Add GPFS smb packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_smb_packages }}"

--- a/roles/smb/upgrade/tasks/main.yml
+++ b/roles/smb/upgrade/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# Install IBM Spectrum Scale (SMB)
+- import_tasks: install.yml
+  tags: install

--- a/roles/smb/upgrade/tasks/yum/install.yml
+++ b/roles/smb/upgrade/tasks/yum/install.yml
@@ -1,0 +1,15 @@
+---
+- name: Initialize
+  set_fact:
+    disable_gpgcheck: "no"
+
+- name: Disable gpg check
+  set_fact:
+    disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS SMB packages
+  yum:
+   name: "{{ scale_install_all_packages }}"
+   state: latest
+   disable_gpg_check: "{{ disable_gpgcheck }}"

--- a/roles/smb/upgrade/tasks/zypper/install.yml
+++ b/roles/smb/upgrade/tasks/zypper/install.yml
@@ -2,5 +2,5 @@
 - name: upgrade | Upgrade GPFS SMB packages
   zypper:
    name: "{{ scale_install_all_packages }}"
-   state: present
+   state: latest
    disable_gpg_check: no

--- a/roles/smb/upgrade/tasks/zypper/install.yml
+++ b/roles/smb/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,6 @@
+---
+- name: upgrade | Upgrade GPFS SMB packages
+  zypper:
+   name: "{{ scale_install_all_packages }}"
+   state: present
+   disable_gpg_check: no

--- a/roles/smb/upgrade/vars/main.yml
+++ b/roles/smb/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (GPFS) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Default scale extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"

--- a/roles/zimon/upgrade/defaults/main.yml
+++ b/roles/zimon/upgrade/defaults/main.yml
@@ -1,0 +1,47 @@
+---
+# Default variables for the IBM Spectrum Scale (GPFS) (Zimon) role -
+# either edit this file or define your own variables to override the defaults
+
+## Specify the URL of the (existing) Spectrum Scale ZIMon YUM repository
+## (copy the contents of /usr/lpp/mmfs/.../zimon_rpms/rhel7 to build your repository)
+# scale_install_repository_url: http://myrepo.com/
+
+## Note that if this is a URL then a new repository definition will be created.
+## If this variable is set to 'existing' then it is assumed that a repository
+## definition already exists and thus will *not* be created.
+
+## Specify the Spectrum Scale architecture that you want to install on your nodes
+scale_architecture: "{{ ansible_architecture }}"
+
+## List of packages to install on GUI collector nodes
+scale_zimon_collector_packages:
+  - gpfs.java*{{ scale_architecture }}
+  - gpfs.gss.pmcollector*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}
+
+scale_zimon_sensors_packages:
+ - gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}
+
+scale_zimon_collector_packages_ubuntu:
+  - gpfs.java
+  - gpfs.gss.pmcollector
+
+scale_zimon_sensors_packages_ubuntu:
+ - gpfs.gss.pmsensors
+
+scale_zimon_collector_packages_suse:
+  - gpfs.java
+  - gpfs.gss.pmcollector
+
+scale_zimon_sensors_packages_suse:
+ - gpfs.gss.pmsensors
+
+## Node's default GUI collector role -
+## you'll likely want to define per-node roles in your inventory
+scale_zimon_collector: false
+
+## Node's default GUI collector role -
+## you'll likely want to define per-node roles in your inventory
+scale_cluster_gui: false
+
+## To Enabled output from Ansible task in stdout and stderr for some tasks.
+## Run the playbook with -vv

--- a/roles/zimon/upgrade/defaults/main.yml
+++ b/roles/zimon/upgrade/defaults/main.yml
@@ -15,21 +15,18 @@ scale_architecture: "{{ ansible_architecture }}"
 
 ## List of packages to install on GUI collector nodes
 scale_zimon_collector_packages:
-  - gpfs.java*{{ scale_architecture }}
   - gpfs.gss.pmcollector*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}
 
 scale_zimon_sensors_packages:
  - gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}
 
 scale_zimon_collector_packages_ubuntu:
-  - gpfs.java
   - gpfs.gss.pmcollector
 
 scale_zimon_sensors_packages_ubuntu:
  - gpfs.gss.pmsensors
 
 scale_zimon_collector_packages_suse:
-  - gpfs.java
   - gpfs.gss.pmcollector
 
 scale_zimon_sensors_packages_suse:

--- a/roles/zimon/upgrade/meta/main.yml
+++ b/roles/zimon/upgrade/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: zimon_node
+  author: IBM Corporation
+  description: Role for installing and configuring IBM Spectrum Scale (GPFS) Zimon
+  company: IBM
+  license: Apache-2.0
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - ibm
+    - spectrum
+    - scale
+    - gpfs
+    - graphical
+    - interface
+    - gui
+
+dependencies:
+  - core/common

--- a/roles/zimon/upgrade/tasks/apt/install.yml
+++ b/roles/zimon/upgrade/tasks/apt/install.yml
@@ -1,0 +1,19 @@
+---
+
+#
+# Install or update RPMs
+#
+- name: upgrade | Upgrade GPFS Zimon packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: latest
+  when: scale_install_repository_url is defined
+
+- block:
+    - name: upgrade | Upgrade GPFS zimon packages
+      apt:
+        deb: "{{ item }}"
+        state: latest
+      with_items:
+        - "{{ scale_install_all_packages }}"
+  when: scale_install_repository_url is not defined

--- a/roles/zimon/upgrade/tasks/install.yml
+++ b/roles/zimon/upgrade/tasks/install.yml
@@ -1,0 +1,73 @@
+---
+# Install or update RPMs
+
+#
+# Ensure that installation method was chosen during previous role
+#
+
+- block:  ## run_once: true
+    - name: upgrade | Check for repository installation method
+      set_fact:
+        scale_installmethod: repository
+      when:
+        - scale_install_repository_url is defined
+        - scale_install_localpkg_path is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+
+    - name: upgrade | Check for localpkg installation method
+      set_fact:
+        scale_installmethod: local_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_directory_pkg_path is undefined
+        - scale_install_localpkg_path is defined
+
+    - name: upgrade | Check for remotepkg installation method
+      set_fact:
+        scale_installmethod: remote_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is defined
+
+    - name: upgrade | Check for directory package installation method
+      set_fact:
+        scale_installmethod: dir_pkg
+      when:
+        - scale_install_repository_url is undefined
+        - scale_install_remotepkg_path is undefined
+        - scale_install_localpkg_path is undefined
+        - scale_install_directory_pkg_path is defined
+
+    - name: upgrade | Check installation method
+      assert:
+        that: scale_installmethod is defined
+        msg: >-
+          Please set the appropriate variable 'scale_install_*' for your desired
+          installation method!
+  run_once: true
+  delegate_to: localhost
+
+#
+# Run chosen installation method to get list of RPMs
+#
+- name: upgrade | Initialize list of packages
+  set_fact:
+    scale_install_all_packages: []
+
+- include_tasks: install_{{ scale_installmethod }}.yml
+
+- meta: flush_handlers
+
+#
+# Install or update RPMs
+#
+- import_tasks: apt/install.yml
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- import_tasks: yum/install.yml
+  when: ansible_distribution in scale_rhel_distribution
+
+- import_tasks: zypper/install.yml
+  when: ansible_distribution in scale_sles_distribution

--- a/roles/zimon/upgrade/tasks/install_dir_pkg.yml
+++ b/roles/zimon/upgrade/tasks/install_dir_pkg.yml
@@ -1,0 +1,100 @@
+---
+# Dir package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat directory installation package
+      stat:
+        path: "{{ scale_install_directory_pkg_path }}"
+      register: scale_install_dirpkg
+
+    - name: upgrade | Check directory installation package
+      assert:
+        that: scale_install_dirpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_directory_pkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+  run_once: true
+  delegate_to: localhost
+
+- name: install| Creates default directory
+  file:
+    path: "{{ scale_extracted_path }}"
+    state: directory
+    mode: a+x
+    recurse: yes
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+  register: scale_install_gpfs_packagedir
+
+#
+# Copy installation directory package to default
+#
+- block:
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_directory_pkg_path }}"
+        dest: "{{ scale_extracted_path }}"
+        mode: a+x
+
+- name: upgrade | Extract installation package
+  set_fact:
+    dir_path: "{{ scale_extracted_path + '/' + scale_install_directory_pkg_path | basename }}"
+
+- name: upgrade | gpfs base path
+  set_fact:
+    scale_gpfs_path_url: "{{ dir_path }}"
+  when: scale_install_directory_pkg_path is defined
+
+#
+# Find Zimon collector
+#
+- block:  ## when: host is defined as a gui node
+    #
+    # Find GPFS gpfs.collector
+    #
+    - name: upgrade | Find gpfs.collector (gpfs.collector) package
+      find:
+        paths: "{{ scale_gpfs_path_url }}"
+        patterns: gpfs.gss.pmcollector*.el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*
+      register: scale_install_gpfs_collector
+
+    - name: upgrade | Check valid GPFS (gpfs.collector) package
+      assert:
+        that: scale_install_gpfs_collector.matched > 0
+        msg: >-
+          No GPFS collector (gpfs.gss.collector) package found:
+          "{{ scale_gpfs_path_url }}/gpfs.gss.pmcollector*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*"
+
+    - name: upgrade | Add GPFS zimon collector packages to list
+      vars:
+        current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_collector.files.0.path | basename }}"
+
+#
+# Find GPFS gpfs.gss.pmsensors
+#
+- name: upgrade | Find gpfs.gss.pmsensors (gpfs.gss.pmsensors) package
+  find:
+    paths: "{{ scale_gpfs_path_url }}"
+    patterns: gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*
+  register: scale_install_gpfs_pmsensors
+
+- name: upgrade | Check valid GPFS (gpfs.gss.pmsensors) package
+  assert:
+    that: scale_install_gpfs_pmsensors.matched > 0
+    msg: >-
+      No GPFS pmsensors (gpfs.gss.pmsensors) package found:
+      "{{ scale_gpfs_path_url }}/gpfs.gss.pmsensors*el{{ ansible_distribution_major_version }}.{{ scale_architecture }}*"
+
+- name: upgrade | Add GPFS zimon sensors packages to list
+  vars:
+    current_package: "{{ scale_gpfs_path_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename }}"

--- a/roles/zimon/upgrade/tasks/install_local_pkg.yml
+++ b/roles/zimon/upgrade/tasks/install_local_pkg.yml
@@ -1,0 +1,200 @@
+---
+# Local package installation method
+
+- block:  ## run_once: true
+    - name: upgrade | Stat local installation package
+      stat:
+        path: "{{ scale_install_localpkg_path }}"
+        checksum_algorithm: md5
+      register: scale_install_localpkg
+
+    - name: upgrade | Check local installation package
+      assert:
+        that: scale_install_localpkg.stat.exists
+        msg: >-
+          Please set the variable 'scale_install_localpkg_path' to point to the
+          local installation package (accessible on Ansible control machine)!
+#
+# Optionally, verify package checksum
+#
+    - name: upgrade | Stat checksum file
+      stat:
+        path: "{{ scale_install_localpkg_path }}.md5"
+      register: scale_install_md5_file
+
+    - block:  ## when: scale_install_md5_file.stat.exists
+        - name: upgrade | Read checksum from file
+          set_fact:
+            scale_install_md5_sum: "{{ lookup('file', scale_install_localpkg_path + '.md5') }}"
+
+        - name: upgrade | Compare checksums
+          assert:
+            that: scale_install_md5_sum.strip().split().0 == scale_install_localpkg.stat.checksum
+            msg: >-
+              Checksums don't match. Please check integritiy of your local
+              installation package!
+      when: scale_install_md5_file.stat.exists
+  run_once: true
+  delegate_to: localhost
+
+#
+# Copy installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- block:  ## when: not scale_install_gpfs_packagedir.stat.exists
+    - name: upgrade | Stat temporary directory
+      stat:
+        path: "{{ scale_install_localpkg_tmpdir_path }}"
+      register: scale_install_localpkg_tmpdir
+
+    - name: upgrade | Check temporary directory
+      assert:
+        that:
+          - scale_install_localpkg_tmpdir.stat.exists
+          - scale_install_localpkg_tmpdir.stat.isdir
+        msg: >-
+          Please set the variable 'scale_install_localpkg_tmpdir_path' to point
+          to a temporary directory on the remote system!
+    - name: upgrade | Copy installation package to node
+      copy:
+        src: "{{ scale_install_localpkg_path }}"
+        dest: "{{ scale_install_localpkg_tmpdir_path }}"
+        mode: a+x
+  when: not scale_install_gpfs_packagedir.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Extract installation package
+  vars:
+    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+  command: "{{ localpkg + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_packagedir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs_packagedir.stat.exists
+      - scale_install_gpfs_packagedir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      local installation package!
+#
+# Delete installation package
+#
+- name: upgrade | Delete installation package from node
+  file:
+    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
+    state: absent
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'el'
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'U'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'sles'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+#
+# Find Zimon collector
+#
+- block:  ## when: host is defined as a gui node
+    #
+    # Find GPFS gpfs.collector
+    #
+    - name: upgrade | Find gpfs.collector (gpfs.collector) RPM
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_zimon_url }}"
+        patterns: gpfs.gss.pmcollector*{{ package_arch }}{{ ansible_distribution_major_version }}*
+      register: scale_install_gpfs_collector
+
+    - name: upgrade | Check valid GPFS (gpfs.collector) RPM
+      assert:
+        that: scale_install_gpfs_collector.matched > 0
+        msg: >-
+          No GPFS collector (gpfs.gss.collector) RPM found:
+          "{{ scale_extracted_path }}/{{ scale_zimon_url }}/gpfs.gss.pmcollector*{{ package_arch }}{{ ansible_distribution_major_version }}*"
+
+    - name: upgrade | Add GPFS zimon collector packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_zimon_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_collector.files.0.path | basename }}"
+
+#
+# Find GPFS gpfs.gss.pmsensors
+#
+- name: upgrade | Find gpfs.gss.pmsensors (gpfs.gss.pmsensors) RPM
+  find:
+    paths: "{{ scale_extracted_path }}/{{ scale_zimon_url }}"
+    patterns: gpfs.gss.pmsensors*{{ package_arch }}{{ ansible_distribution_major_version }}*
+  register: scale_install_gpfs_pmsensors
+
+- name: upgrade | Check valid GPFS (gpfs.gss.pmsensors) RPM
+  assert:
+    that: scale_install_gpfs_pmsensors.matched > 0
+    msg: >-
+      No GPFS pmsensors (gpfs.gss.pmsensors) RPM found:
+      "{{ scale_extracted_path }}/{{ scale_zimon_url }}/gpfs.gss.pmsensors*{{ package_arch }}{{ ansible_distribution_major_version }}*"
+
+
+- name: upgrade | Add GPFS zimon sensors packages to list
+  vars:
+    current_package: "{{ scale_extracted_path }}/{{ scale_zimon_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename }}"

--- a/roles/zimon/upgrade/tasks/install_remote_pkg.yml
+++ b/roles/zimon/upgrade/tasks/install_remote_pkg.yml
@@ -1,0 +1,174 @@
+---
+# Remote package installation method
+
+- name: upgrade | Stat remote installation package
+  stat:
+    path: "{{ scale_install_remotepkg_path }}"
+    checksum_algorithm: md5
+  register: scale_install_remotepkg
+
+- name: upgrade | Check remote installation package
+  assert:
+    that: scale_install_remotepkg.stat.exists
+    msg: >-
+      Please set the variable 'scale_install_remotepkg_path' to point to the
+      remote installation package (accessible on Ansible managed node)!
+
+#
+# Optionally, verify package checksum
+#
+- name: upgrade | Stat checksum file
+  stat:
+    path: "{{ scale_install_remotepkg_path }}.md5"
+  register: scale_install_md5_file
+
+- block:  ## when: scale_install_md5_file.stat.exists
+    - name: upgrade | Read checksum from file
+      slurp:
+        src: "{{ scale_install_remotepkg_path }}.md5"
+      register: scale_install_md5_sum
+
+    - name: upgrade | Compare checksums
+      vars:
+        md5sum: "{{ scale_install_md5_sum.content | b64decode }}"
+      assert:
+        that: md5sum.strip().split().0 == scale_install_remotepkg.stat.checksum
+        msg: >-
+          Checksums don't match. Please check integritiy of your remote
+          installation package!
+  when: scale_install_md5_file.stat.exists
+
+#
+# Extract installation package
+#
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs_rpmdir
+
+- name: upgrade | Make installation package executable
+  file:
+    path: "{{ scale_install_remotepkg_path }}"
+    mode: a+x
+  when: not scale_install_gpfs_rpmdir.stat.exists
+
+- name: upgrade | Extract installation package
+  command: "{{ scale_install_remotepkg_path + ' --silent' }}"
+  args:
+    creates: "{{ scale_gpfs_path_url }}"
+
+- name: upgrade | Stat extracted packages
+  stat:
+    path: "{{ scale_gpfs_path_url }}"
+  register: scale_install_gpfs__rpmdir
+
+- name: upgrade | Check extracted packages
+  assert:
+    that:
+      - scale_install_gpfs__rpmdir.stat.exists
+      - scale_install_gpfs_rpmdir.stat.isdir
+    msg: >-
+      The variable 'scale_version' doesn't seem to match the contents of the
+      remote installation package!
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'el'
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'U'
+  when: ansible_distribution in scale_ubuntu_distribution
+
+- name: upgrade | Set package arch
+  set_fact:
+    package_arch: 'sles'
+  when: ansible_distribution in scale_sles_distribution
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+#
+# Find Zimon collector
+#
+- block:  ## when: host is defined as a gui node
+    #
+    # Find GPFS gpfs.collector
+    #
+    - name: upgrade | Find gpfs.collector (gpfs.collector) RPM
+      find:
+        paths: "{{ scale_extracted_path }}/{{ scale_zimon_url }}"
+        patterns: gpfs.gss.pmcollector*{{ package_arch }}{{ ansible_distribution_major_version }}*
+      register: scale_install_gpfs_collector
+
+    - name: upgrade | Check valid GPFS (gpfs.collector) RPM
+      assert:
+        that: scale_install_gpfs_collector.matched > 0
+        msg: >-
+          No GPFS collector (gpfs.gss.collector) RPM found:
+          "{{ scale_extracted_path }}/{{ scale_zimon_url }}/gpfs.gss.pmcollector*{{ package_arch }}{{ ansible_distribution_major_version }}*"
+
+    - name: upgrade | Add GPFS zimon collector packages to list
+      vars:
+        current_package: "{{ scale_extracted_path }}/{{ scale_zimon_url }}/{{ item }}"
+      set_fact:
+        scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+      with_items:
+        - "{{ scale_install_gpfs_collector.files.0.path | basename }}"
+
+#
+# Find GPFS gpfs.gss.pmsensors
+#
+- name: upgrade | Find gpfs.gss.pmsensors (gpfs.gss.pmsensors) RPM
+  find:
+    paths: "{{ scale_extracted_path }}/{{ scale_zimon_url }}"
+    patterns: gpfs.gss.pmsensors*{{ package_arch }}{{ ansible_distribution_major_version }}*
+  register: scale_install_gpfs_pmsensors
+
+- name: upgrade | Check valid GPFS (gpfs.gss.pmsensors) RPM
+  assert:
+    that: scale_install_gpfs_pmsensors.matched > 0
+    msg: >-
+      No GPFS pmsensors (gpfs.gss.pmsensors) RPM found:
+      "{{ scale_extracted_path }}/{{ scale_zimon_url }}/gpfs.gss.pmsensors*{{ package_arch }}{{ ansible_distribution_major_version }}*"
+
+
+- name: upgrade | Add GPFS zimon sensors packages to list
+  vars:
+    current_package: "{{ scale_extracted_path }}/{{ scale_zimon_url }}/{{ item }}"
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+  with_items:
+    - "{{ scale_install_gpfs_pmsensors.files.0.path | basename }}"

--- a/roles/zimon/upgrade/tasks/install_repository.yml
+++ b/roles/zimon/upgrade/tasks/install_repository.yml
@@ -1,0 +1,126 @@
+---
+# YUM repository installation method
+
+#
+# Configure YUM repository
+#
+- name: Initialize
+  set_fact:
+   scale_zimon_url: ""
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel7/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '7'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/rhel8/'
+  when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu16/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '16'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/ubuntu18/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '18'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_debs/ubuntu/'
+  when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles12/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '12'
+
+- name: upgrade | zimon path
+  set_fact:
+    scale_zimon_url: 'zimon_rpms/sles15/'
+  when: ansible_distribution in scale_sles_distribution and ansible_distribution_major_version == '15'
+
+- name: Initialize
+  set_fact:
+   gpgcheck: "yes"
+
+- name: Disable gpg check
+  set_fact:
+   gpgcheck: "no"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Configure ZIMon YUM repository
+  yum_repository:
+    name: spectrum-scale-zimon
+    description: IBM Spectrum Scale (ZIMon)
+    baseurl: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
+    gpgcheck: "{{ gpgcheck }}"
+    repo_gpgcheck: no
+    state: present
+  notify: yum-clean-metadata
+  when:
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url != 'existing'
+
+- name: upgrade | Configure zimon APT repository
+  apt_repository:
+    filename: spectrum-scale-zimon-debs
+    repo: "deb [trusted=yes] {{ scale_install_repository_url }}{{ scale_zimon_url }} ./"
+    validate_certs: no
+    state: present
+    update_cache: yes
+    codename: IBM Spectrum Scale (Zimon debs)
+    mode: 0777
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url != 'existing'
+
+- debug:
+        msg: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
+
+- name: upgrade | Configure ZIMon repository
+  zypper_repository:
+    name: spectrum-scale-zimon
+    description: IBM Spectrum Scale (ZIMon)
+    repo: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
+    disable_gpg_check: no
+    state: present
+    overwrite_multiple: yes
+  when:
+    - ansible_pkg_mgr == 'zypper'
+
+- name: upgrade | package methods
+  set_fact:
+    scale_zimon_sensors_packages: "{{ scale_zimon_sensors_packages }}"
+    scale_zimon_collector_packages: "{{ scale_zimon_collector_packages }}"
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+
+- name: upgrade | package methods
+  set_fact:
+    scale_zimon_sensors_packages: "{{ scale_zimon_sensors_packages_ubuntu }}"
+    scale_zimon_collector_packages: "{{ scale_zimon_collector_packages_ubuntu }}"
+  when: ansible_pkg_mgr == 'apt'
+
+- name: upgrade | package methods
+  set_fact:
+    scale_zimon_sensors_packages: "{{ scale_zimon_sensors_packages_suse }}"
+    scale_zimon_collector_packages: "{{ scale_zimon_collector_packages_suse }}"
+  when: ansible_pkg_mgr == 'zypper'
+
+#
+# Add GUI packages
+#
+- name: upgrade | Add GPFS sensors packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_zimon_sensors_packages }}"
+
+- name: upgrade | Add GPFS collector packages to list
+  set_fact:
+    scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
+  with_items:
+    - "{{ scale_zimon_collector_packages }}"

--- a/roles/zimon/upgrade/tasks/install_repository.yml
+++ b/roles/zimon/upgrade/tasks/install_repository.yml
@@ -7,6 +7,7 @@
 - name: Initialize
   set_fact:
    scale_zimon_url: ""
+   is_scale_collector_pkg_installed: false
 
 - name: upgrade | zimon path
   set_fact:
@@ -78,9 +79,6 @@
     - ansible_pkg_mgr == 'apt'
     - scale_install_repository_url != 'existing'
 
-- debug:
-        msg: "{{ scale_install_repository_url }}{{ scale_zimon_url }}"
-
 - name: upgrade | Configure ZIMon repository
   zypper_repository:
     name: spectrum-scale-zimon
@@ -110,6 +108,37 @@
     scale_zimon_collector_packages: "{{ scale_zimon_collector_packages_suse }}"
   when: ansible_pkg_mgr == 'zypper'
 
+- name: upgrade | Check if gpfs collector package is installed
+  shell: rpm -q gpfs.gss.pmcollector
+  register: is_collector_package_installed
+  failed_when: no
+  changed_when: no
+  args:
+    warn: false
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf' or ansible_pkg_mgr == 'zypper'
+
+- name: upgrade | Set if gpfs collector package is installed
+  set_fact:
+    is_scale_collector_pkg_installed: true
+  when:
+     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf' or ansible_pkg_mgr == 'zypper'
+     - is_collector_package_installed.rc == 0
+
+- name: upgrade | Check if gpfs collector package is installed
+  shell: dpkg -l | grep gpfs.gss.pmcollector | awk "{print $1}" |  grep ii
+  register: is_collector_apt_package_installed
+  failed_when: no
+  changed_when: no
+  args:
+    warn: false
+  when: ansible_pkg_mgr == 'apt'
+
+- name: upgrade | Set if gpfs collector installed
+  set_fact:
+    is_scale_collector_pkg_installed: true
+  when:
+     - ansible_pkg_mgr == 'apt'
+     - is_collector_apt_package_installed.rc == 0
 #
 # Add GUI packages
 #
@@ -124,3 +153,4 @@
     scale_install_all_packages: "{{ scale_install_all_packages + [ item ] }}"
   with_items:
     - "{{ scale_zimon_collector_packages }}"
+  when: (is_scale_collector_pkg_installed | bool)

--- a/roles/zimon/upgrade/tasks/main.yml
+++ b/roles/zimon/upgrade/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# Install IBM Spectrum Scale (GPFS) Graphical User Interface (GUI)
+
+- import_tasks: install.yml
+  tags: install

--- a/roles/zimon/upgrade/tasks/yum/install.yml
+++ b/roles/zimon/upgrade/tasks/yum/install.yml
@@ -1,0 +1,18 @@
+---
+#
+# Install or update RPMs
+#
+- name: upgrade | Initialize
+  set_fact:
+    scale_disable_gpgcheck: "no"
+
+- name: upgrade | Disable gpg check
+  set_fact:
+    scale_disable_gpgcheck: "yes"
+  when: scale_version < '5.0.4.0'
+
+- name: upgrade | Upgrade GPFS Zimon packages
+  package:
+    name: "{{ scale_install_all_packages }}"
+    state: latest
+    disable_gpg_check: "{{ scale_disable_gpgcheck }}"

--- a/roles/zimon/upgrade/tasks/zypper/install.yml
+++ b/roles/zimon/upgrade/tasks/zypper/install.yml
@@ -1,0 +1,7 @@
+---
+- block:
+    - name: upgrade | Upgrade GPFS zimon packages
+      zypper:
+          name: "{{ scale_install_all_packages }}"
+          state: latest
+          disable_gpg_check: no

--- a/roles/zimon/upgrade/vars/main.yml
+++ b/roles/zimon/upgrade/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Variables for the IBM Spectrum Scale (zimon) role -
+# these variables are *not* meant to be overridden
+
+## Compute RPM version from Spectrum Scale version
+scale_rpmversion: "{{ scale_version | regex_replace('^([0-9.]+)\\.([0-9])$', '\\1-\\2') }}"
+
+## Specify package extraction path
+scale_extracted_default_path: "/usr/lpp/mmfs"
+scale_extracted_path: "{{ scale_extracted_default_path }}/{{ scale_version }}"


### PR DESCRIPTION
Ansible independent upgrade role for all supported component

Note : Upgrade role is not yet supported for external user and we have not yet added this in the work flow. 

This code is similar to  node role of each supported component. 

Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>