### PR TITLE
Incorrect sequence of NFS tasks on IPv6

### DIFF
--- a/roles/nfs/common/tasks/configure.yml
+++ b/roles/nfs/common/tasks/configure.yml
@@ -158,6 +158,7 @@
   shell:
    cmd: "mmces interface mode interface --force"
   when: scale_ces_ipv6_list|length > 0
+  delegate_to: "{{ scale_protocol_node_list.0 }}"
   run_once: true
 
 - name: configure | Add IPv6 interface
@@ -166,6 +167,7 @@
   when: scale_ces_ipv6_list|length > 0 and scale_protocols.interface|length > 0
   with_items:
   - "{{ scale_protocols.interface }}"
+  delegate_to: "{{ scale_protocol_node_list.0 }}"
   run_once: true
 
 - block:

--- a/roles/nfs/common/tasks/configure.yml
+++ b/roles/nfs/common/tasks/configure.yml
@@ -154,17 +154,17 @@
   delegate_to: scale_protocol_node_list.0
   run_once: true
 
+- name: configure | Enable interface mode
+  shell:
+   cmd: "mmces interface mode interface --force"
+  when: scale_ces_ipv6_list|length > 0
+
 - name: configure | Add IPv6 interface
   shell:
    cmd: "{{ scale_command_path }}mmces interface add --nic {{ item }}"
   when: scale_ces_ipv6_list|length > 0 and scale_protocols.interface|length > 0
   with_items:
   - "{{ scale_protocols.interface }}"
-
-- name: configure | Enable interface mode
-  shell:
-   cmd: "mmces interface mode interface --force"
-  when: scale_ces_ipv6_list|length > 0
 
 - block:
   - name: configure | Create CES groups

--- a/roles/nfs/common/tasks/configure.yml
+++ b/roles/nfs/common/tasks/configure.yml
@@ -158,6 +158,7 @@
   shell:
    cmd: "mmces interface mode interface --force"
   when: scale_ces_ipv6_list|length > 0
+  run_once: true
 
 - name: configure | Add IPv6 interface
   shell:
@@ -165,6 +166,7 @@
   when: scale_ces_ipv6_list|length > 0 and scale_protocols.interface|length > 0
   with_items:
   - "{{ scale_protocols.interface }}"
+  run_once: true
 
 - block:
   - name: configure | Create CES groups


### PR DESCRIPTION
Incorrect sequence of NFS tasks on IPv6

Change the order of the NFS task sequence when using Ipv6. 

  Signed-off-by: Christoph Keil <chkeil@de.ibm.com>