### PR TITLE
Avoid update of path in .bashrc with /usr/lpp/mmfs/bin when SELinux is enabled.

### DIFF
--- a/roles/core/precheck/tasks/prepare.yml
+++ b/roles/core/precheck/tasks/prepare.yml
@@ -11,7 +11,9 @@
     path: /root/.bashrc
     line: PATH=$PATH:/usr/lpp/mmfs/bin
     state: present
-  when: ansible_pkg_mgr != 'zypper'
+  when: 
+    - ansible_pkg_mgr != 'zypper'
+    - scale_prepare_disable_selinux | bool
 
 #
 # Configure SSH server


### PR DESCRIPTION
Avoid update of path in .bashrc with /usr/lpp/mmfs/bin when SELinux is enabled.

Signed-off-by: Christoph Keil <chkeil@de.ibm.com>