### PR TITLE
Suppress warning message for Zypper license installation.

### DIFF
--- a/roles/core/node/tasks/install_license_repository.yml
+++ b/roles/core/node/tasks/install_license_repository.yml
@@ -21,6 +21,8 @@
 - name: install | Get license package
   shell:
    cmd: zypper info gpfs.license.* | grep Name | cut -d ':' -f 2 | tr -d '[:space:]'
+  args:
+   warn: false
   register: package_name_version_zypp
   when:
     - ansible_pkg_mgr == 'zypper'


### PR DESCRIPTION
Suppress warning message for Zypper license installation.
Signed-off-by: Christoph Keil <chkeil@de.ibm.com>