### PR TITLE
Dependency error during installation of SMB packages with Ubuntu.

### DIFF
--- a/roles/callhome/node/tasks/install_local_pkg.yml
+++ b/roles/callhome/node/tasks/install_local_pkg.yml
@@ -132,11 +132,11 @@
      that: scale_install_gpfs_callhome.matched > 0
      msg: "No GPFS callhome (gpfs.callhome) package found: {{ scale_callhome_extracted_path }}/{{ callhome_url }}/gpfs.callhome-ecc-client-*"
 
-- name: install | Add GPFS callhome package to list
-  vars:
-   current_package: "{{ item }}"
-  set_fact:
-   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
-  with_items:
-  - "{{ scale_install_gpfs_java.files.0.path }}"
-  - "{{ scale_install_gpfs_callhome.files.0.path }}"
+  - name: install | Add GPFS callhome package to list
+    vars:
+     current_package: "{{ item }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+     - "{{ scale_install_gpfs_java.files.0.path }}"
+     - "{{ scale_install_gpfs_callhome.files.0.path }}"

--- a/roles/callhome/node/tasks/install_remote_pkg.yml
+++ b/roles/callhome/node/tasks/install_remote_pkg.yml
@@ -106,7 +106,7 @@
      that: scale_install_gpfs_callhome.matched > 0
      msg: "No GPFS callhome (gpfs.callhome) package found: {{ scale_callhome_extracted_path }}/{{ callhome_url }}gpfs.callhome-ecc-client*"
 
-- name: install | Add GPFS callhome package to list
+  - name: install | Add GPFS callhome package to list
     vars:
      current_package: "{{ item }}"
     set_fact:

--- a/roles/nfs/node/tasks/install_local_pkg.yml
+++ b/roles/nfs/node/tasks/install_local_pkg.yml
@@ -14,7 +14,6 @@
           Please set the variable 'scale_install_localpkg_path' to point to the
           local installation package (accessible on Ansible control machine)!
 
-
 # Optionally, verify package checksum
 
   - name: install | Stat checksum file
@@ -39,7 +38,6 @@
   delegate_to: localhost
 
 # Copy installation package
-
 
 - name: install | Stat extracted packages
   stat:
@@ -178,9 +176,15 @@
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
-     paths:  "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     paths: "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
      patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
+
+  - name: install | Find gpfs.smb-dbg (gpfs.smb-dbg) package
+    find:
+     paths: "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-dbg*
+    register: scale_install_gpfs_smb_dbg
 
   - name: install | Check valid GPFS (gpfs.smb) package
     assert:
@@ -193,7 +197,9 @@
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
-    - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb_dbg.files }}"
+
   when: ansible_distribution in scale_ubuntu_distribution
 
 - block:  ## when: host is defined as a protocol node
@@ -356,4 +362,4 @@
   when: not install_debuginfo|bool and ansible_distribution in scale_rhel_distribution
 
 - debug:
-        msg: "{{ scale_install_all_packages }}"
+    msg: "{{ scale_install_all_packages }}"

--- a/roles/nfs/node/tasks/install_remote_pkg.yml
+++ b/roles/nfs/node/tasks/install_remote_pkg.yml
@@ -150,9 +150,15 @@
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
-     paths:  "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
+     paths: "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
+
+  - name: install | Find gpfs.smb-dbg (gpfs.smb-dbg) package
+    find:
+     paths: "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-dbg*
+    register: scale_install_gpfs_smb_dbg
 
   - name: install | Check valid GPFS (gpfs.smb) package
     assert:
@@ -165,7 +171,8 @@
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
-    - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb_dbg.files }}"
 
   when: ansible_distribution in scale_ubuntu_distribution
 

--- a/roles/smb/node/tasks/install_local_pkg.yml
+++ b/roles/smb/node/tasks/install_local_pkg.yml
@@ -14,11 +14,8 @@
           Please set the variable 'scale_install_localpkg_path' to point to the
           local installation package (accessible on Ansible control machine)!
 
-#
-
 # Optionally, verify package checksum
 
-#
   - name: install | Stat checksum file
     stat:
      path: "{{ scale_install_localpkg_path }}.md5"
@@ -39,11 +36,8 @@
     when: scale_install_md5_file.stat.exists
   run_once: true
   delegate_to: localhost
-#
 
 # Copy installation package
-
-#
 
 - name: install | Stat extracted packages
   stat:
@@ -71,11 +65,9 @@
      dest: "{{ scale_install_localpkg_tmpdir_path }}"
      mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
-#
 
 # Extract installation package
 
-#
 - name: install | Extract installation package
   vars:
    localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
@@ -96,11 +88,8 @@
    msg: >-
       The variable 'scale_version' doesn't seem to match the contents of the
       local installation package!
-#
 
 # Delete installation package
-
-#
 - name: install | Delete installation package from node
   file:
    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
@@ -141,16 +130,20 @@
    scale_smb_url: 'smb_debs/ubuntu/'
   when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
 
-
 # Find smb rpms
-
 - block:  ## when: host is defined as a protocol node
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
      paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
+     patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
+
+  - name: install | Find gpfs.smb-dbg (gpfs.smb-dbg) package
+    find:
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-dbg*
+    register: scale_install_gpfs_smb_dbg
 
   - name: install | Check valid GPFS (gpfs.smb) package
     assert:
@@ -163,7 +156,9 @@
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
-    - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb_dbg.files }}"
+
   when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
 
 - block:  ## when: host is defined as a protocol node

--- a/roles/smb/node/tasks/install_remote_pkg.yml
+++ b/roles/smb/node/tasks/install_remote_pkg.yml
@@ -105,9 +105,15 @@
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
-     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
+
+  - name: install | Find gpfs.smb-dbg (gpfs.smb-dbg) package
+    find:
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb-dbg*
+    register: scale_install_gpfs_smb_dbg
 
   - name: install | Check valid GPFS (gpfs.smb) package
     assert:
@@ -116,11 +122,12 @@
 
   - name: install | Add GPFS smb package to list
     vars:
-     current_package:  "{{ item.path }}"
+     current_package: "{{ item.path }}"
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
-    - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb.files }}"
+     - "{{ scale_install_gpfs_smb_dbg.files }}"
 
 - block:  ## when: host is defined as a protocol node
 


### PR DESCRIPTION
Dependency error during installation of SMB packages with Ubuntu.
The list of SMB packages which should be installed are in an invalid order.

Signed-off-by: Christoph Keil <chkeil@de.ibm.com>