### PR TITLE
Dependency during installation of SMB packages with Ubntu 18.04.

### DIFF
--- a/roles/callhome/node/tasks/install_local_pkg.yml
+++ b/roles/callhome/node/tasks/install_local_pkg.yml
@@ -132,11 +132,11 @@
      that: scale_install_gpfs_callhome.matched > 0
      msg: "No GPFS callhome (gpfs.callhome) package found: {{ scale_callhome_extracted_path }}/{{ callhome_url }}/gpfs.callhome-ecc-client-*"
 
-- name: install | Add GPFS callhome package to list
-  vars:
-   current_package: "{{ item }}"
-  set_fact:
-   scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
-  with_items:
-  - "{{ scale_install_gpfs_java.files.0.path }}"
-  - "{{ scale_install_gpfs_callhome.files.0.path }}"
+  - name: install | Add GPFS callhome package to list
+    vars:
+     current_package: "{{ item }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+     - "{{ scale_install_gpfs_java.files.0.path }}"
+     - "{{ scale_install_gpfs_callhome.files.0.path }}"

--- a/roles/callhome/node/tasks/install_remote_pkg.yml
+++ b/roles/callhome/node/tasks/install_remote_pkg.yml
@@ -106,7 +106,7 @@
      that: scale_install_gpfs_callhome.matched > 0
      msg: "No GPFS callhome (gpfs.callhome) package found: {{ scale_callhome_extracted_path }}/{{ callhome_url }}gpfs.callhome-ecc-client*"
 
-- name: install | Add GPFS callhome package to list
+  - name: install | Add GPFS callhome package to list
     vars:
      current_package: "{{ item }}"
     set_fact:

--- a/roles/nfs/node/tasks/install_local_pkg.yml
+++ b/roles/nfs/node/tasks/install_local_pkg.yml
@@ -178,7 +178,7 @@
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
-     paths:  "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
+     paths: "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
      patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
 

--- a/roles/nfs/node/tasks/install_remote_pkg.yml
+++ b/roles/nfs/node/tasks/install_remote_pkg.yml
@@ -151,7 +151,7 @@
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
      paths:  "{{ nfs_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
+     patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
 
   - name: install | Check valid GPFS (gpfs.smb) package

--- a/roles/smb/node/tasks/install_local_pkg.yml
+++ b/roles/smb/node/tasks/install_local_pkg.yml
@@ -15,9 +15,7 @@
           local installation package (accessible on Ansible control machine)!
 
 #
-
 # Optionally, verify package checksum
-
 #
   - name: install | Stat checksum file
     stat:
@@ -39,12 +37,10 @@
     when: scale_install_md5_file.stat.exists
   run_once: true
   delegate_to: localhost
-#
 
+#
 # Copy installation package
-
 #
-
 - name: install | Stat extracted packages
   stat:
    path: "{{ smb_extracted_path }}"
@@ -71,10 +67,9 @@
      dest: "{{ scale_install_localpkg_tmpdir_path }}"
      mode: a+x
   when: not scale_install_gpfs_rpmdir.stat.exists
+
 #
-
 # Extract installation package
-
 #
 - name: install | Extract installation package
   vars:
@@ -96,11 +91,8 @@
    msg: >-
       The variable 'scale_version' doesn't seem to match the contents of the
       local installation package!
-#
 
 # Delete installation package
-
-#
 - name: install | Delete installation package from node
   file:
    path: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
@@ -141,31 +133,7 @@
    scale_smb_url: 'smb_debs/ubuntu/'
   when: ansible_distribution in scale_ubuntu_distribution and ansible_distribution_major_version == '20'
 
-
 # Find smb rpms
-
-- block:  ## when: host is defined as a protocol node
-
-  - name: install | Find gpfs.smb (gpfs.smb) package
-    find:
-     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
-    register: scale_install_gpfs_smb
-
-  - name: install | Check valid GPFS (gpfs.smb) package
-    assert:
-     that: scale_install_gpfs_smb.matched > 0
-     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
-
-  - name: install | Add GPFS smb package to list
-    vars:
-     current_package:  "{{ item.path }}"
-    set_fact:
-     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
-    with_items:
-    - "{{ scale_install_gpfs_smb.files }}"
-  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
-
 - block:  ## when: host is defined as a protocol node
 
   - name: install | Find gpfs.smb (gpfs.smb) package
@@ -186,6 +154,28 @@
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:
     - "{{ scale_install_gpfs_smb.files }}"
+  when: ansible_distribution in scale_rhel_distribution or ansible_distribution in scale_sles_distribution
+
+- block:  ## when: host is defined as a protocol node
+
+  - name: install | Find gpfs.smb (gpfs.smb) package
+    find:
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
+    register: scale_install_gpfs_smb
+
+  - name: install | Check valid GPFS (gpfs.smb) package
+    assert:
+     that: scale_install_gpfs_smb.matched > 0
+     msg: "No GPFS smb (gpfs.smb) package found {{ smb_extracted_path }}/{{ scale_smb_url }}gpfs.smb*"
+
+  - name: install | Add GPFS smb package to list
+    vars:
+     current_package: "{{ item.path }}"
+    set_fact:
+     scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
+    with_items:
+    - "{{ scale_install_gpfs_smb.files }}"
   when: ansible_distribution in scale_ubuntu_distribution
 
 
@@ -193,7 +183,7 @@
 
   - name: install | Find gpfs.smb-debuginfo (gpfs.smb-debuginfo) package
     find:
-     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
      patterns: gpfs.smb-debuginfo*
     register: scale_install_gpfs_smb_debuginfo
 

--- a/roles/smb/node/tasks/install_remote_pkg.yml
+++ b/roles/smb/node/tasks/install_remote_pkg.yml
@@ -105,8 +105,8 @@
 
   - name: install | Find gpfs.smb (gpfs.smb) package
     find:
-     paths:  "{{ smb_extracted_path }}/{{ scale_smb_url }}"
-     patterns: gpfs.smb*
+     paths: "{{ smb_extracted_path }}/{{ scale_smb_url }}"
+     patterns: gpfs.smb_*
     register: scale_install_gpfs_smb
 
   - name: install | Check valid GPFS (gpfs.smb) package
@@ -116,7 +116,7 @@
 
   - name: install | Add GPFS smb package to list
     vars:
-     current_package:  "{{ item.path }}"
+     current_package: "{{ item.path }}"
     set_fact:
      scale_install_all_packages: "{{ scale_install_all_packages + [ current_package ] }}"
     with_items:


### PR DESCRIPTION
Dependency during installation of SMB packages with Ubntu 18.04.
The SMB debug package got installed before SMB package.
This cause a problem !

Signed-off-by: Christoph Keil <chkeil@de.ibm.com>