### PR TITLE
Remove unnecessary meta handler call on storage creation

### DIFF
--- a/roles/core/cluster/tasks/storage.yml
+++ b/roles/core/cluster/tasks/storage.yml
@@ -228,7 +228,7 @@
         - item.size > 1
       with_items: "{{ scale_storage_stanzafile_existing.results }}"
 
-    - meta: flush_handlers
+    #- meta: flush_handlers
 
 #
 # Cleanup


### PR DESCRIPTION
Remove unnecessary meta handler call on storage creation
Signed-off-by: Christoph Keil <chkeil@de.ibm.com>