### PR TITLE
Fix Daemon network issue.

### DIFF
--- a/roles/nfs/common/tasks/check.yml
+++ b/roles/nfs/common/tasks/check.yml
@@ -16,7 +16,7 @@
 
 - name: check | Collect all protocol nodes
   set_fact:
-   scale_protocol_node_list: "{{ scale_protocol_node_list + [hostvars[item]['scale_daemon_nodename']] }}"
+   scale_protocol_node_list: "{{ scale_protocol_node_list + [hostvars[item]['scale_admin_nodename']] }}"
   when: hostvars[item]['is_protocol_node'] is defined and hostvars[item]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"


### PR DESCRIPTION
Fix Daemon network issue.
The incorrect node name get used to verify cesSharedRoot is available.

Signed-off-by: Christoph Keil <chkeil@de.ibm.com>