### PR TITLE
Allow Filesystem Metadata Replica to be set during creation

### DIFF
--- a/roles/core/cluster/defaults/main.yml
+++ b/roles/core/cluster/defaults/main.yml
@@ -51,10 +51,13 @@ scale_cluster_manager: false
 ## can be overridden for each filesystem individually
 scale_storage_filesystem_defaults:
   blockSize: 1M
+  maxMetadataReplicas: 2
   defaultMetadataReplicas: 1
+  maxDataReplicas: 2
   defaultDataReplicas: 1
   numNodes: 32
   automaticMountOption: true
+  
   ## defaultMountPoint will be this prefix, followed by the filesystem name
   defaultMountPoint_prefix: /mnt/
   ## Overwrite existing NSDs - if set to 'true' then disks will *not* be checked

--- a/roles/core/cluster/tasks/storage_fs.yml
+++ b/roles/core/cluster/tasks/storage_fs.yml
@@ -96,7 +96,9 @@
         /usr/lpp/mmfs/bin/mmcrfs {{ item.item }}
         -F /var/tmp/StanzaFile.new.{{ item.item }}
         -B {{ scale_storage_fsparams[item.item].blockSize | default(scale_storage_filesystem_defaults.blockSize) }}
+        -M {{ scale_storage_fsparams[item.item].maxMetadataReplicas | default(scale_storage_filesystem_defaults.maxMetadataReplicas) }}
         -m {{ scale_storage_fsparams[item.item].defaultMetadataReplicas | default(scale_storage_filesystem_defaults.defaultMetadataReplicas) }}
+        -R {{ scale_storage_fsparams[item.item].maxDataReplicas | default(scale_storage_filesystem_defaults.maxDataReplicas) }}
         -r {{ scale_storage_fsparams[item.item].defaultDataReplicas | default(scale_storage_filesystem_defaults.defaultDataReplicas) }}
         -n {{ scale_storage_fsparams[item.item].numNodes | default(scale_storage_filesystem_defaults.numNodes) }}
         -A {{ 'yes' if scale_storage_fsparams[item.item].automaticMountOption | default(scale_storage_filesystem_defaults.automaticMountOption) else 'no' }}


### PR DESCRIPTION
Signed-off-by: Muthu A Muthiah mutmuthi@in.ibm.com