### PR TITLE
Add task to import gpg key when using with directory based install

### DIFF
--- a/roles/core/node/tasks/install_dir_pkg.yml
+++ b/roles/core/node/tasks/install_dir_pkg.yml
@@ -50,6 +50,16 @@
   when: scale_install_directory_pkg_path is defined
 
 #
+# Import Spectrum Scale gpg key
+#
+- name: Import a gpg key from a file
+  rpm_key:
+    state: present
+    key: "{{ dir_path }}/SpectrumScale_public_key.pgp"
+  when: ((ansible_distribution in scale_sles_distribution or ansible_distribution in scale_rhel_distribution)
+         and scale_enable_gpg_check and scale_version >= "5.0.5.0")
+
+#
 # Find GPFS BASE
 #
 - name: install | Find GPFS BASE (gpfs.base) package


### PR DESCRIPTION
Adding task to import gpg key.

Closes: #435 