### PR TITLE
Make sure scale_prepare_enable_ssh_login configures the active configuration

### DIFF
--- a/roles/core/precheck/tasks/prepare.yml
+++ b/roles/core/precheck/tasks/prepare.yml
@@ -22,7 +22,7 @@
     - name: prepare | Enable SSH root login
       lineinfile:
         path: /etc/ssh/sshd_config
-        regexp: PermitRootLogin
+        regexp: ^PermitRootLogin
         line: PermitRootLogin yes
         state: present
       notify: reload-sshd


### PR DESCRIPTION

This fixes issue #473 where enabling scale_prepare_enable_ssh_login
would cause duplicate PermitRootLogin lines if it was already configured
to something else than "yes".

Now it will replace if it find ^PermitRootLogin not set to yes, and add 
"PermitRootLogin yes" if it doesn't find it.

Signed-off-by: Jan-Frode Myklebust <janfrode@tanso.net>