### PR TITLE
Extract installer by executing "bash installer", avoid noexec mount problems.

### DIFF
--- a/roles/core/node/tasks/install_local_pkg.yml
+++ b/roles/core/node/tasks/install_local_pkg.yml
@@ -74,7 +74,7 @@
 - name: install | Extract installation package
   vars:
     localpkg: "{{ scale_install_localpkg_tmpdir_path + '/' + scale_install_localpkg_path | basename }}"
-  command: "{{ localpkg + ' --silent' }}"
+  command: "{{ '/bin/bash ' + localpkg + ' --silent' }}"
   args:
     creates: "{{ scale_gpfs_path_url }}"
 


### PR DESCRIPTION

Fixes issue #15.

Signed-off-by: Jan-Frode Myklebust <janfrode@tanso.net>