### PR TITLE
Rename `scale_install_gplbin_rpm` to `scale_install_gplbin_package`

### DIFF
--- a/roles/core/cluster/tasks/install_gplbin.yml
+++ b/roles/core/cluster/tasks/install_gplbin.yml
@@ -29,4 +29,4 @@
 #
 - name: install | Add GPL module RPM to list
   set_fact:
-    scale_install_all_rpms: "{{ scale_install_all_rpms + [ scale_install_gplbin_rpm ] }}"
+    scale_install_all_rpms: "{{ scale_install_all_rpms + [ scale_install_gplbin_package ] }}"

--- a/roles/core/node/defaults/main.yml
+++ b/roles/core/node/defaults/main.yml
@@ -53,7 +53,7 @@ scale_install_gplsrc_packages:
 
 ## Define this variable to install Linux kernel extension from pre-built RPM
 ## (instead of building it from source)
-#scale_install_gplbin_rpm: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
+#scale_install_gplbin_package: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
 
 ## Note that required RPM can be built with `mmbuildgpl --build-package`
 

--- a/roles/core/node/tasks/build.yml
+++ b/roles/core/node/tasks/build.yml
@@ -1,7 +1,7 @@
 ---
 # Build Linux kernel extension from source
 
-- block:  ## when: scale_install_gplbin_rpm is undefined
+- block:  ## when: scale_install_gplbin_package is undefined
 #
 # Install gplsrc prereqs
 #
@@ -92,4 +92,4 @@
         msg: >-
           Unable to build Linux kernel extension for running kernel
           {{ ansible_kernel }}!
-  when: scale_install_gplbin_rpm is undefined
+  when: scale_install_gplbin_package is undefined

--- a/roles/core/precheck/defaults/main.yml
+++ b/roles/core/precheck/defaults/main.yml
@@ -77,7 +77,7 @@ scale_install_gplsrc_rpms:
 
 ## Define this variable to install Linux kernel extension from pre-built RPM
 ## (instead of building it from source)
-#scale_install_gplbin_rpm: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
+#scale_install_gplbin_package: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
 
 ## Note that required RPM can be built with `mmbuildgpl --build-package`
 

--- a/roles/core/upgrade/defaults/main.yml
+++ b/roles/core/upgrade/defaults/main.yml
@@ -58,7 +58,7 @@ scale_hpt_packages:
 
 ## Define this variable to install Linux kernel extension from pre-built RPM
 ## (instead of building it from source)
-#scale_install_gplbin_rpm: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
+#scale_install_gplbin_package: gpfs.gplbin-{{ ansible_kernel }}-{{ scale_rpmversion }}
 
 ## Note that required RPM can be built with `mmbuildgpl --build-package`
 

--- a/roles/core/upgrade/tasks/build.yml
+++ b/roles/core/upgrade/tasks/build.yml
@@ -1,7 +1,7 @@
 ---
 # Build Linux kernel extension from source
 
-- block:  ## when: scale_install_gplbin_rpm is undefined
+- block:  ## when: scale_install_gplbin_package is undefined
 #
 # Identify Linux Distribution
 #
@@ -43,4 +43,4 @@
         msg: >-
           Unable to build Linux kernel extension for running kernel
           {{ ansible_kernel }}!
-  when: scale_install_gplbin_rpm is undefined
+  when: scale_install_gplbin_package is undefined


### PR DESCRIPTION
Fixed a few missing renames... prevent compiler & kernel sources from being installed when using pre-built kernel extension.

Fixes #506 