### PR TITLE
HDFS env variable change

### DIFF
--- a/roles/scale_hdfs/precheck/tasks/prepare_env.yml
+++ b/roles/scale_hdfs/precheck/tasks/prepare_env.yml
@@ -5,7 +5,7 @@
      transparency_version: "False"
 
 - name:
-  shell: "echo $SS_HDFS_33_TRANSPERNCY_VERSION_ENABLE"
+  shell: "echo $SCALE_HDFS_TRANSPARENCY_VERSION_33_ENABLE"
   register: transparency_version
   delegate_to: localhost
   run_once: true


### PR DESCRIPTION
Replacing environment variable from SS_HDFS_33_TRANSPERNCY_VERSION_ENABLE to SCALE_HDFS_TRANSPARENCY_VERSION_33_ENABLE in prepare_env.yml file

Signed-off-by: Dherendra Singh<dhersing@in.ibm.com>