### PR TITLE
Add path to HDFS packages for scale release lower 5.1.2.0

### DIFF
--- a/roles/callhome/node/tasks/zypper/install.yml
+++ b/roles/callhome/node/tasks/zypper/install.yml
@@ -12,3 +12,6 @@
 
 - name: install | Enable repo metadata gpg check
   command: "zypper modifyrepo --default-gpgcheck --all"
+  args:
+    warn: false 
+

--- a/roles/scale_fileauditlogging/node/handlers/main.yml
+++ b/roles/scale_fileauditlogging/node/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for install

--- a/roles/scale_fileauditlogging/node/tasks/install.yml
+++ b/roles/scale_fileauditlogging/node/tasks/install.yml
@@ -51,8 +51,6 @@
 
 - include_tasks: install_{{ scale_installmethod }}.yml
 
-- meta: flush_handlers
-
 #
 # Install or update RPMs
 #

--- a/roles/scale_hdfs/node/defaults/main.yml
+++ b/roles/scale_hdfs/node/defaults/main.yml
@@ -23,5 +23,5 @@ hdfs_rhel_version_path_33: 'hdfs_rpms/rhel/hdfs_3.3.x/'
 # Directory to install 3.1.1.x hdfs package
 hdfs_sles_version_path: 'hdfs_rpms/rhel/hdfs_3.1.1.x/'
 
-# Directory to install 3.3.x hdfs package
+# Directory to install 3.1.1.x hdfs package
 hdfs_ubuntu_version_path: 'hdfs_debs/ubuntu/hdfs_3.1.1.x/'

--- a/roles/scale_hdfs/node/tasks/install.yml
+++ b/roles/scale_hdfs/node/tasks/install.yml
@@ -90,14 +90,28 @@
 - include_tasks: prepare_env.yml
 
 - block:
-  - name:
+  - name: install | Fetch hdfs version 
     set_fact:
-       hdfs_version_path_selection_rhel: "{{ hdfs_rhel_version_path_33 }}"
+      hdfs_version_path_selection_rhel: "{{ hdfs_rhel_version_path_33 }}"
     when: transparency_33_enabled|bool
 
   - name: install | Fetch hdfs rpm dir path for rhel
     set_fact:
-        hdfs_rpm_path_rhel: "{{ hdfs_version_path_selection_rhel }}" 
+      hdfs_rpm_path_rhel: "{{ hdfs_version_path_selection_rhel }}" 
+
+  - name: install | Set correct hdfs rpm dir path for scale release lower 5.1.2
+    set_fact:
+      hdfs_rpm_path_rhel: "{{ hdfs_rpm_path_rhel | replace('/rhel/','/rhel7/') }}" 
+    when: scale_version is version_compare('5.1.2', '<')
+
+  - name: install | Fetch hdfs rpm dir path for sles
+    set_fact:
+      hdfs_rpm_path_sles: "{{ hdfs_sles_version_path }}" 
+  
+  - name: install | Fetch hdfs rpm dir path for ubuntu
+    set_fact:
+      hdfs_rpm_path_ubuntu: "{{ hdfs_ubuntu_version_path }}" 
+
   run_once: true
   delegate_to: localhost
 


### PR DESCRIPTION
Add path to HDFS packages for scale release lower 5.1.2.0
Remove unused ansible handler from FileAditLogging.

 Signed-off-by: Christoph Keil <chkeil@de.ibm.com>