### PR TITLE
Remotemount - Use deamon node Names for contact nodes.

### DIFF
--- a/roles/remote_mount/README.md
+++ b/roles/remote_mount/README.md
@@ -72,6 +72,7 @@ The following variables would need to be defined by the user, either as vars to 
 - ``scale_remotemount_storage_pub_key_location_json:`` (Defaults to : "/tmp/storage_cluster_public_key_json.pub") **Client Cluster (Access) is downloading the pubkey as JSON from Owning cluster**
 - ``scale_remotemount_storage_pub_key_delete:`` (Default to: true) **delete both temporary pubkey after the connection have been established**
 
+-  ``scale_remotemount_storage_adminnodename: true `` (Default to: false) **Spectrum Scale uses the Deamon node name and the IP Attach to connect and run cluster traffic on. In most cases the admin network and deamon network is the same. In case you have different AdminNode address and DeamonNode address and for some reason you want to use admin network, then you can set the variable to true**
 
 Example Playbook's
 -------------------------------

--- a/roles/remote_mount/defaults/main.yml
+++ b/roles/remote_mount/defaults/main.yml
@@ -54,3 +54,8 @@ scale_remotemount_storage_pub_key_delete: true
 # Unmounts, remove the filesystem, and also the connection between Accessing/Client cluster and Owner/Storage Cluster.
 # This only works if both systems have GUI/RESTAPI interface
 scale_remotemount_cleanup_remote_mount: false
+
+# Spectrum Scale uses the Deamon Node Name and the IP Attach to connect and run Cluster traffic. in most cases the admin network and deamon network is the same.
+# In case you have different AdminNode address and DeamonNode address and for some reason you want to use admin network, then you can set the variable: scale_remotemount_storage_adminnodename: true
+# Default = DeamonNodeName
+#scale_remotemount_storage_adminnodename: false

--- a/roles/remote_mount/tasks/main.yml
+++ b/roles/remote_mount/tasks/main.yml
@@ -36,7 +36,7 @@
 - block: # RESTAPI - when: scale_remotemount_client_no_gui == false
     - name: Main | Storage Cluster (owner) | Check Connectivity to Storage Cluster GUI
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
         method: GET
@@ -49,7 +49,18 @@
       run_once: True
       ignore_errors: true
 
-    - name: Main | Unauthorized Storage Cluster (owner)
+    - name: Main | Storage Cluster (owner) | Conenction Refused Storage Cluster
+      run_once: True
+      fail:
+        msg: "There is issues connection to GUI/RestAPI, http return code: {{ storage_cluster_status.status }}"
+      when:
+        - storage_cluster_status.status == -1
+
+    - meta: end_play
+      when:
+        - storage_cluster_status.status == -1
+
+    - name: Main | Storage Cluster (owner) | Unauthorized Storage Cluster
       run_once: True
       fail:
         msg: "The user is not authorized to access the Storage Cluster, http return code: {{ storage_cluster_status.status }}"
@@ -60,9 +71,9 @@
       when:
         - storage_cluster_status.status == 401
 
-    - name: Main | Client Cluster (access) | Check Connectivity to Storage Cluster GUI
+    - name: Main | Client Cluster (access) | Check Connectivity to Client Cluster GUI
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
         method: GET
@@ -75,7 +86,18 @@
       run_once: True
       ignore_errors: true
 
-    - name: Main | Unauthorized Client Cluster (access)
+    - name: Main | Client Cluster (access) | Conenction Refused Client Cluster
+      run_once: True
+      fail:
+        msg: "There is issues connection to GUI/RestAPI, http return code: {{ access_cluster_status.status }}"
+      when:
+        - access_cluster_status.status == -1
+
+    - meta: end_play
+      when:
+        - access_cluster_status.status == -1
+
+    - name: Main | Client Cluster (access) | Unauthorized Client Cluster
       run_once: True
       fail:
         msg: "The user is not authorized to access the Client Cluster, http return code: {{ access_cluster_status.status }}"
@@ -103,7 +125,7 @@
 - block: # RESTAPI-CLI when: scale_remotemount_client_no_gui == true
   - name: Main | API-CLI | Storage Cluster (owner) | Check Connectivity to Storage Cluster GUI
     uri:
-      validate_certs: no
+      validate_certs: "{{ validate_certs_uri }}"
       force_basic_auth: yes
       url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
       method: GET
@@ -115,6 +137,17 @@
     register: storage_cluster_status
     run_once: True
     ignore_errors: true
+
+  - name: Main | API-CLI | Storage Cluster (owner) | Conenction Refused to Storage Cluster
+    run_once: True
+    fail:
+      msg: "There is issues connection to GUI/RestAPI, http return code: {{ access_cluster_status.status }}"
+    when:
+      - storage_cluster_status.status == -1
+
+  - meta: end_play
+    when:
+      - storage_cluster_status.status == -1
 
   - name: Main | API-CLI | Unauthorized Storage Cluster (owner)
     run_once: True

--- a/roles/remote_mount/tasks/remotecluster.yml
+++ b/roles/remote_mount/tasks/remotecluster.yml
@@ -9,7 +9,7 @@
 
 - name: Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
@@ -29,7 +29,7 @@
 
 - name: Client Cluster (access) | GET the Cluster Information
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
@@ -76,7 +76,7 @@
 #
 - name: "Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
@@ -93,7 +93,7 @@
 # TODO: there is no Check if the Storage Cluster (Owner) is allready defined on Client Cluster
 - name: Client Cluster (access) | List the remote cluster already defined
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true
     url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
     method: GET
@@ -126,7 +126,7 @@
   block:
     - name: "DELETE: {{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
@@ -138,7 +138,7 @@
 
     - name: "Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
@@ -160,7 +160,7 @@
 
     - name: Client Cluster (access) | Get the Public Key
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
         method: GET
@@ -180,7 +180,7 @@
 
     - name: Storage Cluster (owner) | Send the Public Key of the Client Cluster (access)
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
         method: POST
@@ -199,7 +199,7 @@
 
     - name: "Storage Cluster (owner) | Check the result of adding the Client Cluster {{ send_key.json.jobs[0].jobId }}"
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
         method: GET
@@ -217,7 +217,7 @@
 
     - name: Storage Cluster (owner) | Get the Public Key
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
         method: GET
@@ -242,7 +242,7 @@
 
     - name: Client Cluster (access) | List the remote cluster already defined
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
         method: GET
@@ -257,9 +257,14 @@
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
 
-    - name: "Storage Cluster (owning) | GET Node Info - GET {{ scalemgmt_endpoint }}/nodes"
+#
+# After a feature improvement we want to grab adminnodename and deamonnode name after where we want the remote mount traffic going over.
+#
+# This section is to gather the nodenames and adminNodeName
+#
+    - name: "Storage Cluster (owning) | GET AdminNodeNames Info - GET {{ scalemgmt_endpoint }}/nodes"
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes
         method: GET
@@ -280,15 +285,45 @@
       with_items: "{{ owning_cluster_nodes.json.nodes }}"
       run_once: True
 
+#
+# This Section is when using daemonNodeName
+#
+    - name: "Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scalemgmt_endpoint }}/nodes/"
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: yes
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/{{item}}
+        method: GET
+        user: "{{ scale_remotemount_storage_gui_username }}"
+        password: "{{ scale_remotemount_storage_gui_password }}"
+        body_format: json
+        status_code:
+         - 200
+      register: owning_cluster_daemonnodes
+      with_items: "{{ owning_nodes_name }}"
+      run_once: True
+
+    - set_fact:
+        owning_daemon_nodes_name: []
+      run_once: True
+
+    - set_fact:
+        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
+      with_items: "{{ owning_cluster_daemonnodes.results }}"
+      run_once: True
+
+#
+# adminNodeName section
+#
     - name: scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
       debug:
         msg: "{{ owning_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
 
-    - name: Client Cluster (access) | Add Storage Cluster as a Remote Cluster
+    - name: Client Cluster (access) | Add Storage Cluster as a Remote Cluster with adminNodeName
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
         method: POST
@@ -303,14 +338,15 @@
           }
         status_code:
           - 202
-      register: uri_result
+      register: adminnode_uri_result
       run_once: True
+      when: scale_remotemount_storage_adminnodename is defined and scale_remotemount_storage_adminnodename | bool
 
-    - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster (JOB: {{ uri_result.json.jobs[0].jobId }})"
+    - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster with adminNodeName (JOB: {{ adminnode_uri_result.json.jobs[0].jobId }})"
       uri:
-        validate_certs: no
+        validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ uri_result.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ adminnode_uri_result.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -319,6 +355,51 @@
       retries: "{{ restapi_retries_count }}"
       delay: "{{ restapi_retries_delay }}"
       run_once: True
+      when: scale_remotemount_storage_adminnodename is defined and scale_remotemount_storage_adminnodename | bool
+#
+# deamonNodeName section
+#
+    - name: scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+      debug:
+        msg: "{{ owning_daemon_nodes_name }}"
+      when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
+      run_once: True
+
+    - name: Client Cluster (access) | Add Storage Cluster as a Remote Cluster with DeamonNodeName
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: true
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+        method: POST
+        user: "{{ scale_remotemount_client_gui_username }}"
+        password: "{{ scale_remotemount_client_gui_password }}"
+        body_format: json
+        body: |
+          {
+            "owningCluster": "{{ owning_cluster_name }}",
+            "key": {{ owningkey_result.json.key | trim | replace(", ", ",") }},
+            "contactNodes": {{ owning_daemon_nodes_name }}
+          }
+        status_code:
+          - 202
+      register: daemonnodesname_uri_result
+      run_once: True
+      when: scale_remotemount_storage_adminnodename is not true
+
+    - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster with DeamonNodeName (JOB: {{ daemonnodesname_uri_result.json.jobs[0].jobId }})"
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: true
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ daemonnodesname_uri_result.json.jobs[0].jobId }}
+        method: GET
+        user: "{{ scale_remotemount_client_gui_username }}"
+        password: "{{ scale_remotemount_client_gui_password }}"
+      register: completed_check
+      until: completed_check.json.jobs[0].status == "COMPLETED"
+      retries: "{{ restapi_retries_count }}"
+      delay: "{{ restapi_retries_delay }}"
+      run_once: True
+      when: scale_remotemount_storage_adminnodename is not true
   when:
     - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
@@ -329,7 +410,7 @@
 
 - name: "Mount Filesystem | Storage Cluster (owner) | Check if filesystems is allready accessible for Client Cluster  ('{{ access_cluster_name }}')"
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
@@ -366,7 +447,7 @@
 
 - name: Mount Filesystem| Storage Cluster (owning) | Allow and Set the client cluster filesystem access attributes on the Storage Cluster
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
     method: POST
@@ -393,9 +474,9 @@
   when:
    - 'item.item.scale_remotemount_storage_filesystem_name not in current_scale_remotemount_storage_filesystem_name'
 
-- name: Mount Filesystem | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster "{{ completed_check.json.jobs[0].jobId }}"
+- name: Mount Filesystem | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster "{{ item.json.jobs.0['jobId'] }}"
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
     method: GET

--- a/roles/remote_mount/tasks/remotecluster_api_cli.yml
+++ b/roles/remote_mount/tasks/remotecluster_api_cli.yml
@@ -220,7 +220,12 @@
         msg: "Add the storage cluster (mmremotecluster add)"
       run_once: True
 
-    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET Node Info - GET {{ scalemgmt_endpoint }}/nodes"
+#
+# After a feature improvements we want to grab adminnodename and deamonnode name after where we want the remote mount traffic going over.
+#
+# This Section is gather the nodenames and adminNodeName
+#
+    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET adminNodeName Info - GET {{ scalemgmt_endpoint }}/nodes"
       uri:
         validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
@@ -243,21 +248,71 @@
       with_items: "{{ owning_cluster_nodes.json.nodes }}"
       run_once: True
 
+#
+# This Section is when using daemonNodeName
+#
+    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scalemgmt_endpoint }}/nodes/"
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: yes
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/{{item}}
+        method: GET
+        user: "{{ scale_remotemount_storage_gui_username }}"
+        password: "{{ scale_remotemount_storage_gui_password }}"
+        body_format: json
+        status_code:
+         - 200
+      register: owning_cluster_daemonnodes
+      with_items: "{{ owning_nodes_name }}"
+      run_once: True
+
+    - set_fact:
+        owning_daemon_nodes_name: []
+      run_once: True
+
+
+    - set_fact:
+        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
+      with_items: "{{ owning_cluster_daemonnodes.results }}"
+      run_once: True
+
+
+#
+# adminNodeName section
+#
     - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
       debug:
         msg: "{{ owning_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
 
-    - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Install storage cluster (owner) public key in remote cluster
+    - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Install storage cluster (owner) public key in remote cluster with adminNodeName
       run_once: True
       shell: |
         /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name }} -n {{ owning_nodes_name | list | join(',') }} -k {{ scale_remotemount_storage_pub_key_location }}
       register: remote_cluster_add_ssh
       failed_when:
         - "remote_cluster_add_ssh.rc != 0 and 'is already defined' not in remote_cluster_add_ssh.stderr"
+      when: scale_remotemount_storage_adminnodename is defined and scale_remotemount_storage_adminnodename | bool
+#
+# deamonNodeName section
+#
+    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+      debug:
+        msg: "{{ owning_daemon_nodes_name }}"
+      when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
+      run_once: True
 
-    - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Cleanup temporary Keys.
+    - name: Remote Cluster Config - API-CLI | Client Cluster (Access) |  Install storage cluster (owner) public key in remote cluster with daemonNodeName
+      run_once: True
+      shell: |
+        /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name }} -n {{ owning_daemon_nodes_name | list | join(',') }} -k {{ scale_remotemount_storage_pub_key_location }}
+      register: remote_cluster_add_ssh
+      failed_when:
+        - "remote_cluster_add_ssh.rc != 0 and 'is already defined' not in remote_cluster_add_ssh.stderr"
+      when: scale_remotemount_storage_adminnodename is not true
+
+    - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Cleanup temporary keys.
       file:
         path: "{{ item }}"
         state: absent

--- a/samples/playbook_remote_mount.yml
+++ b/samples/playbook_remote_mount.yml
@@ -10,18 +10,18 @@
 
 - hosts: localhost
   vars:
-    - scale_remotemount_client_gui_username: admin
-    - scale_remotemount_client_gui_password: Admin@GUI
-    - scale_remotemount_client_gui_hostname: 10.10.10.10
-    - scale_remotemount_storage_gui_username: fs1
-    - scale_remotemount_client_remotemount_path: "/mnt/{{ scale_remotemount_client_filesystem_name }}"
-    - scale_remotemount_storage_gui_username: "{{ scale_remotemount_client_gui_username }}"
-    - scale_remotemount_storage_gui_password: "{{ scale_remotemount_client_gui_password }}"
-    - scale_remotemount_storage_gui_hostname: 10.10.10.20
-    - scale_remotemount_storage_filesystem_name: gpfs01
-  pre_tasks:
+     scale_remotemount_client_gui_username: admin
+     scale_remotemount_client_gui_password: Admin@GUI
+     scale_remotemount_client_gui_hostname: 10.10.10.10
+     scale_remotemount_storage_gui_username: admin
+     scale_remotemount_storage_gui_password: Admin@GUI
+     scale_remotemount_storage_gui_hostname: 10.10.10.20
+     scale_remotemount_filesystem_name:
+      - { scale_remotemount_client_filesystem_name: "fs2", scale_remotemount_client_remotemount_path: "/gpfs/fs2", scale_remotemount_storage_filesystem_name: "gpfs01", } # Minimum variables
+      - { scale_remotemount_client_filesystem_name: "fs3", scale_remotemount_client_remotemount_path: "/gpfs/fs3", scale_remotemount_storage_filesystem_name: "gpfs02", scale_remotemount_client_mount_priority: '2', scale_remotemount_access_mount_attributes: "rw", scale_remotemount_client_mount_fs: "yes"  }
   roles:
     - remote_mount
 
 # If Accessing/Client Cluster don't have GUI,
 # Then change wee need to add variable scale_remotemount_client_no_gui: true and ansible "hosts" need to point to one of the Scale client cluster node
+# See also playbook remote_mount_cli.yml

--- a/samples/playbook_remote_mount_cli.yml
+++ b/samples/playbook_remote_mount_cli.yml
@@ -1,0 +1,25 @@
+---
+#
+# samples/playbook_remote_mount_cli.yml
+#
+
+# Playbook sample for deploying IBM Spectrum Scale (GPFS) cluster with Remote_Mount no GUI on client Cluster
+# enabled. Additional variables need to be defined for this, it is recommended
+# to use Ansible group variables for this purpose:
+# https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-many-machines-group-variables
+
+# Following example will connect up to the first host in your ansible host file, and then run the playbook and do API Call to Storage Cluster.
+# So in this case the Client Cluster node need access on https/443 to Storage Cluster GUI Node.
+
+- hosts: scale-client-cluster-node-1
+  gather_facts: false
+  vars:
+    scale_remotemount_storage_gui_username: admin
+    scale_remotemount_storage_gui_password: Admin@GUI
+    scale_remotemount_storage_gui_hostname: 10.10.10.20
+    scale_remotemount_client_no_gui: true
+    scale_remotemount_filesystem_name:
+      - { scale_remotemount_client_filesystem_name: "fs1", scale_remotemount_client_remotemount_path: "/gpfs/fs1", scale_remotemount_storage_filesystem_name: "gpfs01", } # Minimum variables
+      - { scale_remotemount_client_filesystem_name: "fs2", scale_remotemount_client_remotemount_path: "/gpfs/fs1", scale_remotemount_storage_filesystem_name: "gpfs02", scale_remotemount_client_mount_priority: '2', scale_remotemount_access_mount_attributes: "rw", scale_remotemount_client_mount_fs: "yes"  }
+   roles:
+     - remote_mount


### PR DESCRIPTION
Initially, the role used the admin node name from the Storage Cluster GUI/RestAPI. 

Changed this so the role uses the Deamon node name and the IP Attach, to connect and run cluster traffic on. 
In most cases, the admin network and deamon network is the same. In case you have a different AdminNode address and DeamonNode address and for some reason you want to use admin network, then you can set the variable to true** ``scale_remotemount_storage_adminnodename: true `` (Default to: false)