### PR TITLE
Update 'import_role' tasks to reflect new role names

### DIFF
--- a/roles/ces_common/tasks/configure.yml
+++ b/roles/ces_common/tasks/configure.yml
@@ -103,11 +103,11 @@
   run_once: true
 
 - import_role:
-   name: nfs/node
+   name: ibm.spectrum_scale.nfs_install
   when: scale_ces_disabled_nodes|length > 0 and 'NFS' in scale_service_list
 
 - import_role:
-   name: smb/node
+   name: ibm.spectrum_scale.smb_install
   when: scale_ces_disabled_nodes|length > 0 and 'SMB' in scale_service_list
 
 - name: configure | Prepare ces nodes string


### PR DESCRIPTION
This is a follow up of #572 - the old role names were still being used in `ces_common` in some 'import_role' tasks. This PR replaces these ocurences with the correct (new) name.