### PR TITLE
[CES] Consistently reference protocol nodes by their `inventory_hostname`

### DIFF
--- a/roles/ces_common/tasks/check.yml
+++ b/roles/ces_common/tasks/check.yml
@@ -16,7 +16,7 @@
 
 - name: check | Collect all protocol nodes
   set_fact:
-   scale_protocol_node_list: "{{ scale_protocol_node_list + [hostvars[item]['scale_daemon_nodename']] }}"
+    scale_protocol_node_list: "{{ scale_protocol_node_list + [hostvars[item]['inventory_hostname']] }}"
   when: hostvars[item]['is_protocol_node'] is defined and hostvars[item]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"
@@ -155,21 +155,21 @@ Please define the CES shared root file system mount point in the inventory."
   - name: check | Prepare CES ip list
     set_fact:
      scale_export_ip: "{{ scale_ces_export_ip|flatten }}"
-  
+
   - name: check | Prepare IPv6 export ip list
     set_fact:
      scale_ces_ipv6_list: "{{ scale_ces_ipv6_list + [ item ]}}"
     when: item is regex ( scale_ipv6_regex )
     with_items:
     - "{{ scale_export_ip }}"
-  
+
   - name: check | Prepare IPv4 export ip list
     set_fact:
      scale_ces_ipv4_list: "{{ scale_ces_ipv4_list + [ item ]}}"
     when: item is regex ( scale_ipv4_regex )
     with_items:
     - "{{ scale_export_ip }}"
-  
+
   - name: check | Check if interface is defined
     assert:
      that:
@@ -181,7 +181,7 @@ Please define the CES shared root file system mount point in the inventory."
      msg: "Mixed IPs detected. All CES export IPs can be either IPv4 or IPv6."
     when: scale_ces_ipv4_list|length >0 and scale_ces_ipv6_list|length > 0
     failed_when: scale_ces_ipv4_list|length >0 and scale_ces_ipv6_list|length > 0
-  
+
   when: scale_protocols.scale_ces_groups is defined and scale_protocols.scale_ces_groups|length > 0
 
 - block:
@@ -191,7 +191,7 @@ Please define the CES shared root file system mount point in the inventory."
     when: item is regex ( scale_ipv6_regex )
     with_items:
     - "{{ scale_protocols.export_ip_pool }}"
-      
+
   - name: check | Prepare IPv4 export ip list
     set_fact:
      scale_ces_ipv4_list: "{{ scale_ces_ipv4_list + [ item ]}}"
@@ -207,9 +207,8 @@ Please define the CES shared root file system mount point in the inventory."
 
   - name: check | Check if all ces ips are either IPv4 or IPv6
     debug:
-     msg: "Mixed IPs detected. All CES export IPs can be either IPv4 or IPv6." 
+     msg: "Mixed IPs detected. All CES export IPs can be either IPv4 or IPv6."
     when: scale_ces_ipv4_list|length >0 and scale_ces_ipv6_list|length > 0
     failed_when: scale_ces_ipv4_list|length >0 and scale_ces_ipv6_list|length > 0
- 
-  when: scale_protocols.scale_ces_groups is not defined 
 
+  when: scale_protocols.scale_ces_groups is not defined

--- a/roles/ces_common/tasks/configure.yml
+++ b/roles/ces_common/tasks/configure.yml
@@ -21,9 +21,9 @@
 
 - name: configure | Prepare server nodes string
   set_fact:
-   scale_server_nodes: "{{ scale_server_nodes + ',' + item|string }}"
+    scale_server_nodes: "{{ scale_server_nodes + ',' + hostvars[item]['scale_daemon_nodename'] | string }}"
   with_items:
-  - "{{ scale_protocol_node_list }}"
+    - "{{ scale_protocol_node_list }}"
 
 - name: configure | Setting server licenses on protocol nodes
   command: "{{ scale_command_path }}mmchlicense server --accept -N {{ scale_server_nodes[1:] }}"
@@ -42,8 +42,8 @@
 
 - name: configure | Collect all nodes on which ces is not enabled
   set_fact:
-    scale_ces_disabled_nodes: "{{ scale_ces_disabled_nodes + [ item ]}}"
-  when: not scale_ces_enable_status.stdout_lines is search(item)
+    scale_ces_disabled_nodes: "{{ scale_ces_disabled_nodes + [hostvars[item]['scale_daemon_nodename']] }}"
+  when: not scale_ces_enable_status.stdout_lines is search(hostvars[item]['scale_daemon_nodename'])
   with_items:
     - "{{ scale_protocol_node_list }}"
 
@@ -52,14 +52,13 @@
    name: iputils-arping
    state: present
   when: (ansible_distribution in scale_ubuntu_distribution) and
-        (ansible_fqdn in scale_protocol_node_list or inventory_hostname in scale_protocol_node_list)
+        (inventory_hostname in scale_protocol_node_list)
 
 - name: configure | Check if SMB is running
   shell:
    cmd: "{{ scale_command_path }}mmces service list|grep SMB"
   register: scale_service_status
-  when: (ansible_fqdn in scale_protocol_node_list) or
-        (inventory_hostname in scale_protocol_node_list)
+  when: inventory_hostname in scale_protocol_node_list
   ignore_errors: true
   failed_when: false
   run_once: true
@@ -67,14 +66,14 @@
 - name: configure | Add SMB service to list
   set_fact:
    scale_service_list: "{{ scale_service_list + [scale_service_status.stderr|regex_search('SMB')] }}"
-  when: (ansible_fqdn in scale_protocol_node_list or inventory_hostname in scale_protocol_node_list) and
+  when: (inventory_hostname in scale_protocol_node_list) and
         ( scale_service_status.rc > 0 )
   run_once: true
 
 - name: configure | Add SMB service to list
   set_fact:
    scale_service_list: "{{ scale_service_list + ['SMB'] }}"
-  when: (ansible_fqdn in scale_protocol_node_list or inventory_hostname in scale_protocol_node_list) and
+  when: (inventory_hostname in scale_protocol_node_list) and
         ( scale_service_status.rc == 0 )
   run_once: true
 
@@ -82,8 +81,7 @@
   shell:
    cmd: "{{ scale_command_path }}mmces service list|grep NFS"
   register: scale_service_status
-  when: (ansible_fqdn in scale_protocol_node_list) or
-        (inventory_hostname in scale_protocol_node_list)
+  when: inventory_hostname in scale_protocol_node_list
   ignore_errors: true
   failed_when: false
   run_once: true
@@ -91,14 +89,14 @@
 - name: configure | Add NFS service to the list
   set_fact:
    scale_service_list: "{{ scale_service_list + [scale_service_status.stderr|regex_search('NFS')] }}"
-  when: (ansible_fqdn in scale_protocol_node_list or inventory_hostname in scale_protocol_node_list) and
+  when: (inventory_hostname in scale_protocol_node_list) and
         ( scale_service_status.rc > 0 )
   run_once: true
 
 - name: configure | Add NFS service to the list
   set_fact:
    scale_service_list: "{{ scale_service_list + ['NFS'] }}"
-  when: (ansible_fqdn in scale_protocol_node_list or inventory_hostname in scale_protocol_node_list) and
+  when: (inventory_hostname in scale_protocol_node_list) and
         ( scale_service_status.rc == 0 )
   run_once: true
 
@@ -128,10 +126,10 @@
 
   #- name: configure | Collect status of ces nodes
   #shell:
-  # cmd: "{{ scale_command_path }}mmces node list|grep {{ item }}"
+  # cmd: "{{ scale_command_path }}mmces node list|grep {{ hostvars[item]['scale_daemon_nodename'] }}"
   #register: scale_ces_enable_status
   #with_items:
-  #- "{{ scale_protocol_node_list }}"
+  #  - "{{ scale_protocol_node_list }}"
   #delegate_to: "{{ scale_protocol_node_list.0 }}"
 
   #- name: configure | Check CES enabled on all nodes
@@ -157,7 +155,7 @@
 - name: configure| Check CES enabled on all nodes
   assert:
     that:
-      - "item in scale_ces_enable_status.stdout"
+      - hostvars[item]['scale_daemon_nodename'] in scale_ces_enable_status.stdout
     fail_msg: "CES is not enabled on {{ item }} protocol node"
     success_msg: "Successful enabling of CES on protocol node {{ item }}"
   with_items:
@@ -192,8 +190,7 @@
 
   - name: configure | Assign export ips as pool for CES groups
     command: "{{ scale_command_path }}mmces address add --ces-ip {{ item.export_ip_pool|join(',') }} --ces-group {{ item.group_name}}"
-    when: (ansible_fqdn in scale_protocol_node_list) or
-          (inventory_hostname in scale_protocol_node_list)
+    when: inventory_hostname in scale_protocol_node_list
     delegate_to: "{{ scale_protocol_node_list.0 }}"
     with_items:
     - "{{ scale_protocols.scale_ces_groups }}"
@@ -218,7 +215,7 @@
 
 - name: configure | Rebalance CES IPs
   command: "{{ scale_command_path }}mmces address move --rebalance"
-  #when: ansible_fqdn in scale_protocol_node_list
+  #when: inventory_hostname in scale_protocol_node_list
   delegate_to: "{{ scale_protocol_node_list.0 }}"
   run_once: true
 

--- a/roles/hdfs_install/tasks/yum/install.yml
+++ b/roles/hdfs_install/tasks/yum/install.yml
@@ -4,5 +4,4 @@
    name: "{{ scale_install_all_packages }}"
    state: present
    disable_gpg_check: "{{ scale_disable_gpgcheck }}"
-  when: ansible_fqdn in scale_hdfs_nodes_list or ansible_fqdn in scale_protocol_nodes_list
-
+  when: ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_protocol_nodes_list

--- a/roles/hdfs_prepare/tasks/check.yml
+++ b/roles/hdfs_prepare/tasks/check.yml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: prepare_env.yml
-  
+
 - debug:
    msg: "transparency_33_enabled: {{ transparency_33_enabled|bool }}"
 
@@ -12,7 +12,7 @@
 
 - name: check | Collect all protocol nodes
   set_fact:
-   scale_protocol_nodes_list: "{{ scale_protocol_nodes_list + [hostvars[hosts]['ansible_fqdn']] }}"
+    scale_protocol_nodes_list: "{{ scale_protocol_nodes_list + [hostvars[hosts]['inventory_hostname']] }}"
   when: hostvars[hosts]['is_protocol_node'] is defined and hostvars[hosts]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"
@@ -68,7 +68,7 @@
 
 - fail:
     msg: "Not sufficient CESIPs are assigned in export_ip_pool for HDFS clusters, please add more CESIP and retry."
-  when: 
+  when:
     - hdfs_cluster_length|int > export_cesip_length|int
   delegate_to: localhost
   run_once: true
@@ -116,4 +116,3 @@
 - debug:
     msg: "HDFS Precheck ok"
   when: scale_hdfs_clusters|length == 1
-

--- a/roles/nfs_install/tasks/apt/install.yml
+++ b/roles/nfs_install/tasks/apt/install.yml
@@ -3,12 +3,12 @@
   package:
    name: "{{ scale_install_all_packages }}"
    state: present
-  when: scale_install_repository_url is defined and ansible_fqdn in scale_nfs_nodes_list
+  when: scale_install_repository_url is defined and inventory_hostname in scale_nfs_nodes_list
 
 - name: install| Install GPFS NFS deb
   apt:
    deb: "{{ item }}"
    state: present
-  when: scale_install_repository_url is not defined and ansible_fqdn in scale_nfs_nodes_list
+  when: scale_install_repository_url is not defined and inventory_hostname in scale_nfs_nodes_list
   with_items:
   - "{{ scale_install_all_packages }}"

--- a/roles/nfs_install/tasks/install.yml
+++ b/roles/nfs_install/tasks/install.yml
@@ -72,4 +72,4 @@
   package:
    name: rpcbind
    state: present
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list

--- a/roles/nfs_install/tasks/yum/install.yml
+++ b/roles/nfs_install/tasks/yum/install.yml
@@ -4,4 +4,4 @@
    name: "{{ scale_install_all_packages }}"
    state: present
    disable_gpg_check: "{{ scale_disable_gpgcheck }}"
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list

--- a/roles/nfs_prepare/tasks/check.yml
+++ b/roles/nfs_prepare/tasks/check.yml
@@ -11,7 +11,7 @@
 
 - name: check | Collect all nfs nodes
   set_fact:
-   scale_nfs_nodes_list: "{{ scale_nfs_nodes_list + [hostvars[item]['ansible_fqdn']] }}"
+   scale_nfs_nodes_list: "{{ scale_nfs_nodes_list + [hostvars[item]['inventory_hostname']] }}"
   when: hostvars[item]['is_protocol_node'] is defined and hostvars[item]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"
@@ -31,7 +31,7 @@
   shell:
    cmd: systemctl status nfs-server
   register: scale_nfs_status
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   ignore_errors: true
   failed_when: false
 
@@ -41,14 +41,14 @@
    - scale_nfs_status.rc > 0
    fail_msg: "Service nfs found running on {{ ansible_hostname }}. Which conflicts with the installation of NFS.
 SUGGESTTED ACTION- Run commands to stop (systemctl stop nfs) and disable (systemctl disable nfs) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   any_errors_fatal: true
 
 - name: check | Collect status of service nfs-kernel-server
   shell:
    cmd: systemctl status nfs-kernel-server
   register: scale_nfs_status
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   ignore_errors: true
   failed_when: false
 
@@ -59,14 +59,14 @@ SUGGESTTED ACTION- Run commands to stop (systemctl stop nfs) and disable (system
    fail_msg: "Service nfs-kernel-server found running on {{ ansible_hostname }}. Which conflicts with the installation of NFS.
 SUGGESTTED ACTION Run commands to stop (systemctl stop nfs-kernel-server) and disable (systemctl disable nfs-kernel-server)
 this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   any_errors_fatal: true
 
 - name: check | Collect status of service knfs-server
   shell:
    cmd: systemctl status knfs-server
   register: scale_nfs_status
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   ignore_errors: true
   failed_when: false
 
@@ -77,5 +77,5 @@ this service on node {{ ansible_hostname }}"
    fail_msg: "Service knfs-kernel-server found running on {{ ansible_hostname }}. Which conflicts with the installation of NFS.
 SUGGESTTED ACTION Run commands to stop (systemctl stop knfs-server) and disable (systemctl disable knfs-server)
 this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   any_errors_fatal: true

--- a/roles/nfs_verify/tasks/check.yml
+++ b/roles/nfs_verify/tasks/check.yml
@@ -3,7 +3,7 @@
   shell:
    cmd: "{{ scale_command_path }}mmces service list|grep NFS"
   register: scale_nfs_status
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list
   failed_when: false
 
 - name: postcheck | Check if NFS is running
@@ -11,4 +11,4 @@
    that:
    - scale_nfs_status.rc == 0
    fail_msg: "NFS is not active on {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_nfs_nodes_list
+  when: inventory_hostname in scale_nfs_nodes_list

--- a/roles/obj_configure/tasks/configure.yml
+++ b/roles/obj_configure/tasks/configure.yml
@@ -48,21 +48,21 @@
 
 - name: configure | Set configuration parameter to configure OBJ
   set_fact:
-    obj_param: "-g {{ scale_protocols.mountpoint }} -o {{ scale_ces_obj.object_fileset }} --cluster-hostname {{ scale_obj_nodes_list.0 }} --pwd-file {{ scale_ces_obj.pwd_file }}"
+    obj_param: "-g {{ scale_protocols.mountpoint }} -o {{ scale_ces_obj.object_fileset }} --cluster-hostname {{ hostvars[scale_obj_nodes_list.0]['scale_daemon_nodename'] }} --pwd-file {{ scale_ces_obj.pwd_file }}"
   delegate_to: "{{ scale_obj_nodes_list.0 }}"
   when:
      - not scale_ces_dynamic_obj|bool
   run_once: True
 
-- name: configure | Check local-keystone is defined 
+- name: configure | Check local-keystone is defined
   set_fact:
-    obj_param: "{{ obj_param }} --local-keystone" 
-  when: 
+    obj_param: "{{ obj_param }} --local-keystone"
+  when:
      - scale_ces_obj.local_keystone is defined and scale_ces_obj.local_keystone|bool
      - not scale_ces_dynamic_obj|bool
   delegate_to: "{{ scale_obj_nodes_list.0 }}"
   run_once: True
- 
+
 - name: configure | Check enable-s3 is defined
   set_fact:
     obj_param: "{{ obj_param }} --enable-s3"
@@ -80,7 +80,7 @@
      - not scale_ces_dynamic_obj|bool
   delegate_to: "{{ scale_obj_nodes_list.0 }}"
   run_once: true
- 
+
 #
 # Configure Object
 #
@@ -104,8 +104,8 @@
       register: scale_ces_enable_obj_service
 
     - name: configure | Show OBJ Service is enabled
-      debug: 
-        var: scale_ces_enable_obj_service.stdout_lines 
+      debug:
+        var: scale_ces_enable_obj_service.stdout_lines
 
     # Start Object on CES
     - name: configure | Start OBJ Service
@@ -124,4 +124,4 @@
 
   when: obj_enabled is defined and not obj_enabled
   delegate_to: "{{ scale_obj_nodes_list.0 }}"
-  run_once: true 
+  run_once: true

--- a/roles/obj_install/tasks/install_dir_pkg.yml
+++ b/roles/obj_install/tasks/install_dir_pkg.yml
@@ -84,5 +84,4 @@
         msg: "No Scale object (spectrum-scale-object) package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: when: ansible_fqdn in scale_protocol_node_list 
-
+  when: inventory_hostname in scale_protocol_node_list

--- a/roles/obj_install/tasks/install_local_pkg.yml
+++ b/roles/obj_install/tasks/install_local_pkg.yml
@@ -99,13 +99,13 @@
 
 # Find object rpms
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list 
+- block: ## when: inventory_hostname in scale_obj_nodes_list
     - name: install | obj path
       set_fact:
         scale_obj_url: 'object_rpms/rhel8'
       when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
 
-    - name: install | Find all packages 
+    - name: install | Find all packages
       find:
         paths:  "{{ obj_extracted_path }}/{{ scale_obj_url }}"
         patterns: "*.rpm"
@@ -132,5 +132,4 @@
         msg: "No Scale object spectrum-scale-object package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: ansible_fqdn in scale_obj_nodes_list 
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_install/tasks/install_pmswift.yml
+++ b/roles/obj_install/tasks/install_pmswift.yml
@@ -5,7 +5,7 @@
 
 # Add pmswift rpm
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list
+- block: ## when: inventory_hostname in scale_obj_nodes_list
 
     - name: install | pmswift path
       set_fact:
@@ -45,5 +45,4 @@
         scale_install_all_packages: "{{ scale_install_all_packages + pmswift_package }}"
       when: scale_install_repository_url is undefined
 
-  when: ansible_fqdn in scale_obj_nodes_list
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_install/tasks/install_remote_pkg.yml
+++ b/roles/obj_install/tasks/install_remote_pkg.yml
@@ -73,7 +73,7 @@
 
 # Find object rpms
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list
+- block: ## when: inventory_hostname in scale_obj_nodes_list
     - name: install | obj path
       set_fact:
         scale_obj_url: 'object_rpms/rhel8'
@@ -106,5 +106,4 @@
         msg: "No Scale object spectrum-scale-object package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: ansible_fqdn in scale_obj_nodes_list
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_install/tasks/yum/install.yml
+++ b/roles/obj_install/tasks/yum/install.yml
@@ -4,12 +4,12 @@
    name: "{{ scale_install_all_packages }}"
    state: present
    disable_gpg_check: "{{ scale_disable_gpgcheck }}"
-  when: ansible_fqdn in scale_obj_nodes_list
+  when: inventory_hostname in scale_obj_nodes_list
 
 - name: install | Get installed spectrum-scale-object
   shell: rpm -qa | grep spectrum-scale-object
   register: scale_package_status
-  when: ansible_fqdn in scale_obj_nodes_list
+  when: inventory_hostname in scale_obj_nodes_list
   ignore_errors: true
   args:
     warn: false
@@ -19,5 +19,4 @@
     that:
     - scale_package_status.rc == 0
     fail_msg: "spectrum-scale-object is not installed on {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_obj_nodes_list
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_prepare/tasks/check.yml
+++ b/roles/obj_prepare/tasks/check.yml
@@ -12,7 +12,7 @@
 
 - name: check | Collect all object nodes
   set_fact:
-    scale_obj_nodes_list: "{{ scale_obj_nodes_list + [hostvars[item]['ansible_fqdn']] }}"
+    scale_obj_nodes_list: "{{ scale_obj_nodes_list + [hostvars[item]['inventory_hostname']] }}"
   when: hostvars[item]['is_protocol_node'] is defined and hostvars[item]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"

--- a/roles/obj_upgrade/tasks/install_dir_pkg.yml
+++ b/roles/obj_upgrade/tasks/install_dir_pkg.yml
@@ -84,5 +84,4 @@
         msg: "No Scale object (spectrum-scale-object) package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: when: ansible_fqdn in scale_protocol_node_list 
-
+  when: inventory_hostname in scale_protocol_node_list

--- a/roles/obj_upgrade/tasks/install_local_pkg.yml
+++ b/roles/obj_upgrade/tasks/install_local_pkg.yml
@@ -101,13 +101,13 @@
 
 # Find object rpms
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list 
+- block: ## when: inventory_hostname in scale_obj_nodes_list
     - name: upgrade | obj path
       set_fact:
         scale_obj_url: 'object_rpms/rhel8'
       when: ansible_distribution in scale_rhel_distribution and ansible_distribution_major_version == '8'
 
-    - name: upgrade | Find all packages 
+    - name: upgrade | Find all packages
       find:
         paths: "{{ obj_extracted_path }}/{{ scale_obj_url }}"
         patterns: "*.rpm"
@@ -134,5 +134,4 @@
         msg: "No Scale object spectrum-scale-object package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: ansible_fqdn in scale_obj_nodes_list 
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_upgrade/tasks/install_pmswift.yml
+++ b/roles/obj_upgrade/tasks/install_pmswift.yml
@@ -5,7 +5,7 @@
 
 # Add pmswift rpm
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list
+- block: ## when: inventory_hostname in scale_obj_nodes_list
     - name: upgrade | pmswift path
       set_fact:
         scale_obj_url: 'zimon_rpms/rhel8'
@@ -24,9 +24,11 @@
          - "{{ scale_obj_sensors_packages }}"
       when: scale_install_repository_url is defined
 
-    - name: upgrade | Add pmswift package name 
+    - name: upgrade | Add pmswift package name
       vars:
         pmswift_package: "{{ object_package.files | map(attribute='path') | list}}"
       set_fact:
         scale_install_all_packages: "{{ scale_install_all_packages + pmswift_package }}"
       when: scale_install_repository_url is undefined
+
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_upgrade/tasks/install_remote_pkg.yml
+++ b/roles/obj_upgrade/tasks/install_remote_pkg.yml
@@ -73,7 +73,7 @@
 
 # Find object rpms
 
-- block: ## when: ansible_fqdn in scale_obj_nodes_list
+- block: ## when: inventory_hostname in scale_obj_nodes_list
     - name: upgrade | obj path
       set_fact:
         scale_obj_url: 'object_rpms/rhel8'
@@ -106,5 +106,4 @@
         msg: "No Scale object spectrum-scale-object package found {{ obj_extracted_path }}/{{ scale_obj_url }}/spectrum-scale-object*"
       run_once: true
 
-  when: ansible_fqdn in scale_obj_nodes_list
-
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/obj_verify/tasks/check.yml
+++ b/roles/obj_verify/tasks/check.yml
@@ -4,7 +4,7 @@
   shell:
    cmd: "{{ scale_command_path }}mmces service list|grep OBJ"
   register: scale_obj_status
-  when: ansible_fqdn in scale_obj_nodes_list
+  when: inventory_hostname in scale_obj_nodes_list
   failed_when: false
 
 - name: postcheck | Check if OBJ is running
@@ -12,4 +12,4 @@
    that:
    - scale_obj_status.rc == 0
    fail_msg: "OBJ is not active on {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_obj_nodes_list
+  when: inventory_hostname in scale_obj_nodes_list

--- a/roles/perfmon_configure/tasks/configure.yml
+++ b/roles/perfmon_configure/tasks/configure.yml
@@ -60,7 +60,7 @@
     #TODO: added a check for output, but are having problems using the ( collector_nodes | join(',') ) to use when adding nodes.
     - name: configure | Initialize performance collection
       vars:
-        collector_nodes: "{{ groups['scale_zimon_collectors'] | list }}"
+        collector_nodes: "{{ groups['scale_zimon_collectors'] | map('extract', hostvars, 'scale_daemon_nodename') | list }}"
       command: /usr/lpp/mmfs/bin/mmperfmon config generate --collectors {{ collector_nodes | join(',') }}
       register: scale_zimon_conf_pmcollector
       when:
@@ -73,7 +73,7 @@
 
     - name: configure | update performance collection for new node
       vars:
-        collector_nodes_new: "{{ groups['scale_zimon_collectors'] | list }}"
+        collector_nodes_new: "{{ groups['scale_zimon_collectors'] | map('extract', hostvars, 'scale_daemon_nodename') | list }}"
       command: /usr/lpp/mmfs/bin/mmperfmon config update --collectors "{{ collector_nodes_new | join(',') }}"
       register: scale_zimon_update_pmcollector
       when:

--- a/roles/smb_install/tasks/apt/install.yml
+++ b/roles/smb_install/tasks/apt/install.yml
@@ -3,14 +3,13 @@
   package:
    name: "{{ scale_install_all_packages }}"
    state: present
-  when: scale_install_repository_url is defined and ansible_fqdn in scale_smb_node_list
+  when: scale_install_repository_url is defined and inventory_hostname in scale_smb_node_list
 
 
 - name: install| Install GPFS SMB deb
   apt:
    deb: "{{ item }}"
    state: present
-  when: scale_install_repository_url is not defined and ansible_fqdn in scale_smb_node_list
+  when: scale_install_repository_url is not defined and inventory_hostname in scale_smb_node_list
   with_items:
   - "{{ scale_install_all_packages }}"
-

--- a/roles/smb_install/tasks/yum/install.yml
+++ b/roles/smb_install/tasks/yum/install.yml
@@ -4,5 +4,4 @@
    name: "{{ scale_install_all_packages }}"
    state: present
    disable_gpg_check: "{{ scale_disable_gpgcheck }}"
-  when: ansible_fqdn in scale_smb_node_list
-
+  when: inventory_hostname in scale_smb_node_list

--- a/roles/smb_install/tasks/zypper/install.yml
+++ b/roles/smb_install/tasks/zypper/install.yml
@@ -4,4 +4,4 @@
    name: "{{ scale_install_all_packages }}"
    state: present
    disable_gpg_check: no
-  when: ansible_fqdn in scale_smb_node_list
+  when: inventory_hostname in scale_smb_node_list

--- a/roles/smb_prepare/tasks/check.yml
+++ b/roles/smb_prepare/tasks/check.yml
@@ -5,7 +5,7 @@
 
 - name: check | Collect all smb nodes
   set_fact:
-   scale_smb_node_list: "{{ scale_smb_node_list + [hostvars[item]['ansible_fqdn']] }}"
+    scale_smb_node_list: "{{ scale_smb_node_list + [hostvars[item]['inventory_hostname']] }}"
   when: hostvars[item]['is_protocol_node'] is defined and hostvars[item]['is_protocol_node']|bool
   with_items:
    - "{{ ansible_play_hosts }}"
@@ -30,7 +30,7 @@
    that:
    - ansible_facts.services["smb"].state != "running"
    fail_msg: "Service smb found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop smb) and disable (systemctl disable smb) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["smb"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["smb"].state is defined
   any_errors_fatal: true
 
 - name: check | Check if service smbd is running
@@ -38,7 +38,7 @@
    that:
    - ansible_facts.services["smbd"].state != "running"
    fail_msg: "Service smbd found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop smbd) and disable (systemctl disable smbd) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["smbd"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["smbd"].state is defined
   any_errors_fatal: true
 
 - name: check | Check if service winbind is running
@@ -46,7 +46,7 @@
    that:
    - ansible_facts.services["winbind"].state != "running"
    fail_msg: "Service smb found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop winbind) and disable (systemctl disable winbind) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["winbind"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["winbind"].state is defined
   any_errors_fatal: true
 
 - name: check | Check if service winbindd is running
@@ -54,7 +54,7 @@
    that:
    - ansible_facts.services["winbindd"].state != "running"
    fail_msg: "Service winbindd found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop winbindd) and disable (systemctl disable winbindd) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["winbindd"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["winbindd"].state is defined
   any_errors_fatal: true
 
 - name: check | Check if service ctdb is running
@@ -62,7 +62,7 @@
    that:
    - ansible_facts.services["ctdb"].state != "running"
    fail_msg: "Service ctdb found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop ctdb) and disable (systemctl disable ctdb) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["ctdb"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["ctdb"].state is defined
   any_errors_fatal: true
 
 - name: check | Check if service ctdbd is running
@@ -70,7 +70,7 @@
    that:
    - ansible_facts.services["ctdbd"].state != "running"
    fail_msg: "Service ctdbd found running on {{ ansible_hostname }}. Which conflicts with the installation of SMB.SUGGESTTED ACTION- Run commands to stop (systemctl stop ctdbd) and disable (systemctl disable ctdbd) this service on node {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list and ansible_facts.services["ctdbd"].state is defined
+  when: inventory_hostname in scale_smb_node_list and ansible_facts.services["ctdbd"].state is defined
   any_errors_fatal: true
 
 - debug:

--- a/roles/smb_verify/tasks/check.yml
+++ b/roles/smb_verify/tasks/check.yml
@@ -3,7 +3,7 @@
   shell:
    cmd: "{{ scale_command_path }}mmces service list|grep SMB"
   register: scale_smb_status
-  when: ansible_fqdn in scale_smb_node_list
+  when: inventory_hostname in scale_smb_node_list
   ignore_errors: true
   failed_when: false
 
@@ -12,4 +12,4 @@
    that:
    - scale_smb_status.rc == 0
    fail_msg: "SMB is not active on {{ ansible_hostname }}"
-  when: ansible_fqdn in scale_smb_node_list
+  when: inventory_hostname in scale_smb_node_list


### PR DESCRIPTION
The problem is described in detail in #577. This PR changes various lists used in CES components to consistenly reference nodes by their `inventory_hostname`.

This inventory name can be translated into a host's GPFS nodename (e.g. in loops) like so:
```yaml
hostvars[item]['scale_daemon_nodename']
```

The following lists were changed:
- `scale_protocol_node_list` used in **ces_common**
- `scale_obj_nodes_list` used in **Object**
- `scale_nfs_nodes_list` used in **NFS**
- `scale_smb_node_list` used in **SMB**
- `scale_protocol_nodes_list` used in **HDFS**

With these changes I can successfully run the same playbook, regardless if my managed hosts are defined with their short name or their long name (FQDN) in my inventory file.

Fixes #577.