### PR TITLE
Consistently check if `scale_install_repository_url` is defined

### DIFF
--- a/roles/afm_cos_install/tasks/install_repository.yml
+++ b/roles/afm_cos_install/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure HPT APT repository
@@ -29,6 +30,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure HPT repository
@@ -41,6 +43,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/afm_cos_upgrade/tasks/install_repository.yml
+++ b/roles/afm_cos_upgrade/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure HPT APT repository
@@ -29,6 +30,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure HPT repository
@@ -41,6 +43,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/callhome_install/tasks/install_repository.yml
+++ b/roles/callhome_install/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure Callhome APT repository
@@ -29,6 +30,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure Callhome zypper repository
@@ -40,6 +42,7 @@
     disable_gpg_check: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/core_configure/tasks/install_gplbin.yml
+++ b/roles/core_configure/tasks/install_gplbin.yml
@@ -13,8 +13,9 @@
     state: present
   notify: yum-clean-metadata
   when:
-    - ansible_pkg_mgr == 'yum'
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 
 #
 # Add kernel extension prereqs

--- a/roles/core_install/tasks/install_gplbin.yml
+++ b/roles/core_install/tasks/install_gplbin.yml
@@ -15,6 +15,7 @@
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 
 - name: install | Configure GPL module repository
   apt_repository:
@@ -26,6 +27,7 @@
   when:
     - ansible_pkg_mgr == 'apt'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 
 - name: install | Configure GPL module repository
   zypper_repository:
@@ -37,6 +39,7 @@
   when:
     - ansible_pkg_mgr == 'zypper'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 #
 # Add kernel extension prereqs
 #

--- a/roles/core_install/tasks/install_repository.yml
+++ b/roles/core_install/tasks/install_repository.yml
@@ -17,6 +17,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure apt repository
@@ -32,6 +33,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure zypper repository
@@ -46,6 +48,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/core_upgrade/tasks/install_gplbin.yml
+++ b/roles/core_upgrade/tasks/install_gplbin.yml
@@ -15,6 +15,7 @@
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 
 - name: upgrade | Configure GPL module repository
   apt_repository:
@@ -26,6 +27,7 @@
   when:
     - ansible_pkg_mgr == 'apt'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 
 - name: upgrade | Configure GPL module repository
   zypper_repository:
@@ -37,6 +39,7 @@
   when:
     - ansible_pkg_mgr == 'zypper'
     - scale_install_gplbin_repository_url is defined
+    - scale_install_gplbin_repository_url != 'existing'
 #
 # Add kernel extension prereqs
 #

--- a/roles/core_upgrade/tasks/install_repository.yml
+++ b/roles/core_upgrade/tasks/install_repository.yml
@@ -20,6 +20,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure apt repository
@@ -35,6 +36,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure zypper repository
@@ -49,6 +51,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/ece_install/tasks/install_repository.yml
+++ b/roles/ece_install/tasks/install_repository.yml
@@ -20,6 +20,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Add GPFS gnr packages to list

--- a/roles/ece_upgrade/tasks/install_repository.yml
+++ b/roles/ece_upgrade/tasks/install_repository.yml
@@ -20,6 +20,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Add GPFS gnr packages to list

--- a/roles/fal_install/tasks/install_repository.yml
+++ b/roles/fal_install/tasks/install_repository.yml
@@ -40,6 +40,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure apt repository
@@ -55,6 +56,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure zypper repository
@@ -69,8 +71,9 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
- 
+
 - name: install | Configure fal YUM repository
   yum_repository:
     name: spectrum-scale-fal
@@ -83,6 +86,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure fal APT repository
@@ -96,6 +100,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure fal repository
@@ -107,6 +112,8 @@
     state: present
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
+    - scale_install_repository_url != 'existing'
 
 #
 # Add FAL packages

--- a/roles/fal_upgrade/tasks/install_repository.yml
+++ b/roles/fal_upgrade/tasks/install_repository.yml
@@ -47,6 +47,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure apt repository
@@ -62,6 +63,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 #
 # Configure zypper repository
@@ -76,8 +78,9 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
- 
+
 - name: upgrade | Configure fal YUM repository
   yum_repository:
     name: spectrum-scale-fal
@@ -90,6 +93,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure fal APT repository
@@ -103,6 +107,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure fal repository
@@ -114,6 +119,8 @@
     state: present
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
+    - scale_install_repository_url != 'existing'
 
 #
 # Add FAL packages

--- a/roles/gui_install/tasks/install_repository.yml
+++ b/roles/gui_install/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure gui APT repository
@@ -29,6 +30,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure GUI repository
@@ -41,6 +43,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/gui_upgrade/tasks/install_repository.yml
+++ b/roles/gui_upgrade/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure gui APT repository
@@ -29,6 +30,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure GUI repository
@@ -41,6 +43,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 #

--- a/roles/hdfs_install/tasks/install_repository.yml
+++ b/roles/hdfs_install/tasks/install_repository.yml
@@ -21,6 +21,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Add GPFS hdfs packages to list

--- a/roles/hdfs_upgrade/tasks/upgrade_repository.yml
+++ b/roles/hdfs_upgrade/tasks/upgrade_repository.yml
@@ -24,6 +24,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Add GPFS hdfs packages to list

--- a/roles/nfs_install/tasks/install_repository.yml
+++ b/roles/nfs_install/tasks/install_repository.yml
@@ -86,6 +86,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure nfs APT repository
@@ -99,6 +100,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure smb APT repository
@@ -112,6 +114,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure nfs zypper repository
@@ -123,6 +126,7 @@
     disable_gpg_check: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install|configure pm-ganesha YUM repository
@@ -137,6 +141,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure pm-ganesha APT repository
@@ -150,6 +155,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure pm-ganesha zypper repository
@@ -162,6 +168,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Add GPFS nfs packages to list

--- a/roles/nfs_upgrade/tasks/install_repository.yml
+++ b/roles/nfs_upgrade/tasks/install_repository.yml
@@ -66,6 +66,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure nfs APT repository
@@ -79,6 +80,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure nfs zypper repository
@@ -90,6 +92,7 @@
     disable_gpg_check: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install|configure pm-ganesha YUM repository
@@ -104,6 +107,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure pm-ganesha APT repository
@@ -117,6 +121,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure pm-ganesha zypper repository
@@ -129,6 +134,7 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Add GPFS nfs packages to list

--- a/roles/obj_install/tasks/install_pmswift.yml
+++ b/roles/obj_install/tasks/install_pmswift.yml
@@ -23,6 +23,7 @@
       notify: yum-clean-metadata
       when:
         - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+        - scale_install_repository_url is defined
         - scale_install_repository_url != 'existing'
 
     - name: install | Find pmswift packages

--- a/roles/obj_install/tasks/install_repository.yml
+++ b/roles/obj_install/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Add GPFS object packages to list

--- a/roles/obj_upgrade/tasks/install_repository.yml
+++ b/roles/obj_upgrade/tasks/install_repository.yml
@@ -16,6 +16,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Add GPFS object packages to list

--- a/roles/perfmon_install/tasks/install_repository.yml
+++ b/roles/perfmon_install/tasks/install_repository.yml
@@ -55,6 +55,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure zimon APT repository
@@ -68,6 +69,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure ZIMon repository
@@ -80,12 +82,14 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
+    - scale_install_repository_url != 'existing'
 
 - name: install | package methods
   set_fact:
     scale_zimon_sensors_packages: "{{ scale_zimon_sensors_packages }}"
     scale_zimon_collector_packages: "{{ scale_zimon_collector_packages }}"
-  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf' 
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
 
 - name: install | package methods
   set_fact:

--- a/roles/perfmon_upgrade/tasks/install_repository.yml
+++ b/roles/perfmon_upgrade/tasks/install_repository.yml
@@ -57,6 +57,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure zimon APT repository
@@ -70,6 +71,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure ZIMon repository
@@ -82,6 +84,8 @@
     overwrite_multiple: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
+    - scale_install_repository_url != 'existing'
 
 - name: upgrade | package methods
   set_fact:
@@ -180,7 +184,7 @@
             - pmswiftd
           when:
              - scale_pmswift_status.rc is defined and scale_pmswift_status.rc == 0
-      when: 
+      when:
          - (is_scale_pmswift_pkg_installed | bool)
 
     - name: upgrade | pmswift packages to list

--- a/roles/smb_install/tasks/install_repository.yml
+++ b/roles/smb_install/tasks/install_repository.yml
@@ -46,6 +46,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure smb zypper repository
@@ -57,6 +58,7 @@
     disable_gpg_check: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Configure smb APT repository
@@ -70,6 +72,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: install | Add GPFS smb packages to list

--- a/roles/smb_upgrade/tasks/install_repository.yml
+++ b/roles/smb_upgrade/tasks/install_repository.yml
@@ -46,6 +46,7 @@
   notify: yum-clean-metadata
   when:
     - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure smb zypper repository
@@ -57,6 +58,7 @@
     disable_gpg_check: yes
   when:
     - ansible_pkg_mgr == 'zypper'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Configure smb APT repository
@@ -70,6 +72,7 @@
     mode: 0777
   when:
     - ansible_pkg_mgr == 'apt'
+    - scale_install_repository_url is defined
     - scale_install_repository_url != 'existing'
 
 - name: upgrade | Add GPFS smb packages to list


### PR DESCRIPTION
Before creating YUM / APT / Zypper repositories, consistently check if repository URL variable is defined. This fixes local package installation in certain configs - see #574 for an example.

Furthermore, consistently check if the repository URL is not defined as the special string `existing`. In this case, skip repository creation.