### PR TITLE
RemoteCluster Improvements - Logics, ContactNodes, GPFS Deamon Check, Specify nodes to mount FS

### DIFF
--- a/roles/remotemount_configure/defaults/main.yml
+++ b/roles/remotemount_configure/defaults/main.yml
@@ -58,4 +58,32 @@ scale_remotemount_cleanup_remote_mount: false
 # Spectrum Scale uses the Deamon Node Name and the IP Attach to connect and run Cluster traffic. in most cases the admin network and deamon network is the same.
 # In case you have different AdminNode address and DeamonNode address and for some reason you want to use admin network, then you can set the variable: scale_remotemount_storage_adminnodename: true
 # Default = DeamonNodeName
-#scale_remotemount_storage_adminnodename: false
+scale_remotemount_storage_adminnodename: false
+
+
+# Added check that GPFS deamon is started on GUI node, it will check the first server in NodeClass GUI_MGMT_SERVERS
+# Check can be disabled with changing the flag to false.
+scale_remotemount_gpfsdemon_check: true
+
+# Default it will try to mount the filesystem on all client cluster (accessing) nodes, here you can replace the this with a comma seperated list of servers.
+# scale1-test,scale2-test
+# scale_remotemount_client_mount_on_nodes: all
+
+# When we are adding the storage Cluster in client cluster we need to spesify what nodes should be used. and in normal cases all nodes would be fine.
+# In cases we have AFM Gateway nodes, or Cloud nodes TFCT, we want to use the RESTAPI filter to remove those nodes so they are not used.
+# Example and the default below is to only list all servers that have (AFM) gatewayNode=false.
+scale_remotemount_storage_contactnodes_filter: '?fields=roles.gatewayNode%2Cnetwork.daemonNodeName&filter=roles.gatewayNode%3Dfalse'
+# Examples:
+# NO AFM and CloudGateway: ?fields=roles.gatewayNode%2Cnetwork.daemonNodeName%2Croles.cloudGatewayNode&filter=roles.gatewayNode%3Dfalse%2Croles.cloudGatewayNode%3Dfalse
+# to create your own filter, go to the API Explorer on Spectrum Scale GUI. https://IP-TO-GUI-NODE/ibm/api/explorer/#!/Spectrum_Scale_REST_API_v2/nodesGetv2
+# Roles in version 5.1.1.3
+#      "roles": {
+#        "cesNode": false,
+#        "cloudGatewayNode": false,
+#        "cnfsNode": false,
+#        "designation": "quorum",
+#        "gatewayNode": false,
+#        "managerNode": false,
+#        "otherNodeRoles": "perfmonNode",
+#        "quorumNode": true,
+#        "snmpNode": false

--- a/roles/remotemount_configure/tasks/main.yml
+++ b/roles/remotemount_configure/tasks/main.yml
@@ -108,6 +108,76 @@
       when:
         - access_cluster_status.status == 401
 
+    - name: Main | Client Cluster (access) | Check status of GPFS deamon (Nodeclass GUI_MGMT_SERVERS)
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: true
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+        method: GET
+        user: "{{ scale_remotemount_client_gui_username }}"
+        password: "{{ scale_remotemount_client_gui_password }}"
+        body_format: json
+        return_content: yes
+        status_code:
+          - 200
+      register: clientcluster_gpfs_deamon_status
+      run_once: True
+      when: scale_remotemount_gpfsdemon_check | bool
+
+    - name: Main | Client Cluster (access) | Print status of GPFS deamon on GUI_MGMT_SERVERS - Debug
+      run_once: True
+      ignore_errors: true
+      debug:
+        msg: "{{ clientcluster_gpfs_deamon_status.json.states[0].state }}"
+      when:
+        - scale_remotemount_gpfsdemon_check | bool
+        - scale_remotemount_debug is defined
+        - scale_remotemount_debug | bool
+
+    - name: Main | Client Cluster (access) | GPFS Deamon on Client Cluster is down (Nodeclass GUI_MGMT_SERVERS)
+      run_once: True
+      assert:
+        that:
+          - "'HEALTHY' or 'DEGRADED' in storagecluster_gpfs_deamon_status.json.states[0].state"
+        fail_msg: "'GPFS Deamon is NOT started on NodeClass GUI_MGMT_SERVERS"
+        success_msg: "'GPFS Deamon is started on NodeClass GUI_MGMT_SERVERS"
+      when: scale_remotemount_gpfsdemon_check | bool
+
+    - name: Main | Storage Cluster (owning) | Check status of gpfs deamon on GUI_MGMT_SERVERS
+      uri:
+        validate_certs: "{{ validate_certs_uri }}"
+        force_basic_auth: true
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+        method: GET
+        user: "{{ scale_remotemount_storage_gui_username }}"
+        password: "{{ scale_remotemount_storage_gui_password }}"
+        body_format: json
+        return_content: yes
+        status_code:
+          - 200
+      register: storagecluster_gpfs_deamon_status
+      run_once: True
+      when: scale_remotemount_gpfsdemon_check | bool
+
+    - name: Main | storage Cluster (owning) | Print status of GPFS deamon on GUI_MGMT_SERVERS - Debug
+      run_once: True
+      ignore_errors: true
+      debug:
+        msg: "{{ storagecluster_gpfs_deamon_status.json.states[0].state }}"
+      when:
+        - scale_remotemount_gpfsdemon_check | bool
+        - scale_remotemount_debug is defined
+        - scale_remotemount_debug | bool
+
+    - name: Main | Storage Cluster (owning) | GPFS Deamon on Storage Cluster is down (Nodeclass GUI_MGMT_SERVERS)
+      run_once: True
+      assert:
+        that:
+          - "'HEALTHY' or 'DEGRADED' in storagecluster_gpfs_deamon_status.json.states[0].state"
+        fail_msg: "'GPFS Deamon is NOT started on NodeClass GUI_MGMT_SERVERS"
+        success_msg: "'GPFS Deamon is started on NodeClass GUI_MGMT_SERVERS"
+      when: scale_remotemount_gpfsdemon_check | bool
+
     - name: msg
       debug:
         msg: "Force Run was passed in, attempting to run remote_mount role regardless of whether the filesystem is configured."
@@ -160,16 +230,51 @@
     when:
       - storage_cluster_status.status == 401
 
+  - name: Main | API-CLI | Storage Cluster (owning) | Check status of gpfs deamon on GUI_MGMT_SERVERS
+    uri:
+      validate_certs: "{{ validate_certs_uri }}"
+      force_basic_auth: true
+      url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+      method: GET
+      user: "{{ scale_remotemount_storage_gui_username }}"
+      password: "{{ scale_remotemount_storage_gui_password }}"
+      body_format: json
+      return_content: yes
+      status_code:
+        - 200
+    register: storagecluster_gpfs_deamon_status
+    run_once: True
+    when: scale_remotemount_gpfsdemon_check | bool
+
+  - name: Main | API-CLI |  Storage Cluster (owning) | Print status of GPFS deamon on GUI_MGMT_SERVERS - Debug
+    run_once: True
+    ignore_errors: true
+    debug:
+      msg: "{{ storagecluster_gpfs_deamon_status.json.states[0].state }}"
+    when:
+      - scale_remotemount_gpfsdemon_check | bool
+      - scale_remotemount_debug is defined
+      - scale_remotemount_debug | bool
+
+  - name: Main | API-CLI | Storage Cluster (owning) | GPFS Deamon on Storage Cluster is down (Nodeclass GUI_MGMT_SERVERS)
+    run_once: True
+    assert:
+      that:
+        - "'HEALTHY' or 'DEGRADED' in storagecluster_gpfs_deamon_status.json.states[0].state"
+      fail_msg: "'GPFS Deamon is NOT started on NodeClass GUI_MGMT_SERVERS"
+      success_msg: "'GPFS Deamon is started on NodeClass GUI_MGMT_SERVERS"
+    when: scale_remotemount_gpfsdemon_check | bool
+
   - name: Main | API-CLI | Force Run
     debug:
-      msg: "Force Run was passed in, attempting to run remote_mount role regardless of whether the filesystem is configured."
+      msg: "Force Run was passed in, attempting to run remote_mount role regardless of whether the filesystem is configured"
     when: scale_remotemount_forceRun | bool
 
   - name: Main | API-CLI | Configure Remote Cluster
     include_tasks: remotecluster_api_cli.yml
     run_once: True
 
-  - name: Main | API-CLI | Remote mount the filesystem's
+  - name: Main | API-CLI | Remote Mount the filesystems
     include_tasks: mount_filesystem_api_cli.yml
     run_once: True
 

--- a/roles/remotemount_configure/tasks/mount_filesystem_api_cli.yml
+++ b/roles/remotemount_configure/tasks/mount_filesystem_api_cli.yml
@@ -9,7 +9,7 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
     method: GET
@@ -57,7 +57,7 @@
 
 - name: "Mount Filesystem - Rest-API | Storage Cluster (owner) | Check if filesystems is allready accessible for Client Cluster  ('{{ access_cluster_name }}')"
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
@@ -92,7 +92,7 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owning) | Allow and Set the client cluster filesystem access attributes on the Storage Cluster
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
     method: POST
@@ -121,7 +121,7 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster ##"{{ completed_check.json.jobs[0].jobId }}"
   uri:
-    validate_certs: no
+    validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
     method: GET
@@ -168,7 +168,7 @@
   debug:
     msg: "Add the remotefileystem and mount it on the Client Side"
 
-- name: Mount Filesystem - Rest-API | Client Cluster (access) | Add remote filesystem
+- name: Mount Filesystem - Rest-API | Client Cluster (access) | Add remote filesystem - Output is from check.
   run_once: True
   shell: |
     /usr/lpp/mmfs/bin/mmremotefs add {{ item.item.scale_remotemount_client_filesystem_name }} -f {{ item.item.scale_remotemount_storage_filesystem_name }} -C {{ owning_cluster_name }} -T {{ item.item.scale_remotemount_client_remotemount_path }} -o  {{ item.item.scale_remotemount_access_mount_attributes | default ('rw') }} -A {{ item.item.scale_remotemount_client_mount_fs | default ('yes') }} --mount-priority {{ item.item.scale_remotemount_client_mount_priority | default ('0') }}
@@ -212,14 +212,13 @@
   fail:
     msg: "Scale/GPFS deamon is NOT running on one or serveral of your client cluster node. Check and run mmount manually"
   when: "'down' in gpfs_deamon_state.stdout"
-  ignore_errors: true
   run_once: true
 
 # Not adding any check here, run only when when mmremotefs add task is also run.
 
-- name: Client Cluster (access) | Mount remote filesystem on all client nodes
+- name: Client Cluster (access) | Mount remote filesystem on all client nodes - Output is from previous task, check if the filesystem's is allready mounted
   run_once: True
-  command: /usr/lpp/mmfs/bin/mmmount {{ item.item.scale_remotemount_client_filesystem_name }} -N {{ accessing_nodes_name }}
+  command: /usr/lpp/mmfs/bin/mmmount {{ item.item.scale_remotemount_client_filesystem_name }} -N {{ scale_remotemount_client_mount_on_nodes | default('all') }}
   loop: "{{ remote_filesystem_results_cli.results }}"
   when:
     - item.rc != 0 or scale_remotemount_forceRun | bool
@@ -231,7 +230,7 @@
 
 # Adding a stdout from previous as the stdout from the loop abow can be confusing when several loops.
 
-- name:  Client Cluster (access) | Mount remote filesystem on all client nodes - Show stdout from the previous task.
+- name:  Client Cluster (access) | Mount remote filesystem on all client nodes - Shows stdout from the previous task.
   debug:
     msg: "Message from mount remote filesystem task: {{ item }}"
   loop: "{{ client_cluster_mount_remotefs | json_query('results[*].stdout') }}"

--- a/roles/remotemount_configure/tasks/mount_filesystems.yml
+++ b/roles/remotemount_configure/tasks/mount_filesystems.yml
@@ -1,5 +1,51 @@
 ---
-- name: Step 7 - Configure and Mount filesystems
+
+
+- name: Step 7 - Check status of GPFS deamon on all nodes before mounting filesystem.
+  debug:
+    msg: "Check status of GPFS deamon on all nodes before mounting filesystem "
+  run_once: True
+#
+# Cheking that GPFS deamon is started on all nodes, else the adding and mounting of filesystem fails.
+# RestAPI filters for GPFS deamon on all nodes with the state FAILED.
+#
+- name: Client Cluster (access) | Check status of GPFS deamon on all nodes before mounting filesystem.
+  uri:
+    validate_certs: "{{ validate_certs_uri }}"
+    force_basic_auth: true
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/%3Aall%3A/health/states?fields=component%2Cstate&filter=component%3DGPFS%2Cstate%3DFAILED
+    method: GET
+    user: "{{ scale_remotemount_client_gui_username }}"
+    password: "{{ scale_remotemount_client_gui_password }}"
+    body_format: json
+    return_content: yes
+    status_code:
+      - 200
+  register: clientcluster_gpfs_deamon_all_status
+  run_once: True
+  when: scale_remotemount_gpfsdemon_check | bool
+
+- name: Client Cluster (access) | Print status of GPFS deamon - Debug
+  run_once: True
+  ignore_errors: true
+  debug:
+    msg: "{{ clientcluster_gpfs_deamon_all_status.json.states }}"
+  when:
+    - scale_remotemount_gpfsdemon_check | bool
+    - scale_remotemount_debug is defined
+    - scale_remotemount_debug | bool
+
+- name: Client Cluster (access) | One or more GPFS Deamon on Client Cluster is down.
+  run_once: True
+  assert:
+    that:
+      - "{{ clientcluster_gpfs_deamon_all_status.json.states|length == 0 }}"
+    fail_msg: "'GPFS Deamon is NOT started on all nodes, so mounting of filesystem will fail "
+    success_msg: "'GPFS Deamon is started on all nodes"
+  when:
+    - scale_remotemount_gpfsdemon_check | bool
+
+- name: Step 8 - Configure and Mount filesystems
   debug:
     msg: "Check if remotefileystem '{{ filesystem_loop.scale_remotemount_client_filesystem_name }}' is already defined on Client Cluster"
   run_once: True
@@ -21,7 +67,7 @@
 
 - name: block
   block:
-    - name: Step 8
+    - name: Step 9
       debug:
         msg: "Add the remotefileystem '{{ filesystem_loop.scale_remotemount_client_filesystem_name }}' and mount it on the Client Cluster (access)"
       run_once: True
@@ -43,7 +89,7 @@
             "remoteMountPath": "{{ filesystem_loop.scale_remotemount_client_remotemount_path | realpath }}",
             "mountOptions": "{{ filesystem_loop.scale_remotemount_access_mount_attributes | default('rw') }}",
             "automount": "{{ filesystem_loop.scale_remotemount_client_mount_fs | default('yes') }}",
-            "mountOnNodes": "all"
+            "mountOnNodes": "{{ scale_remotemount_client_mount_on_nodes | default('all') }}"
           }
         status_code:
           - 202

--- a/roles/remotemount_configure/tasks/remotecluster.yml
+++ b/roles/remotemount_configure/tasks/remotecluster.yml
@@ -90,7 +90,9 @@
   run_once: True
 
 #
-# TODO: there is no Check if the Storage Cluster (Owner) is allready defined on Client Cluster
+# TODO: there is no Check if the Storage Cluster (Owner) is allready defined on Client Cluster, so in some cases where storage cluster have connection to client cluster (mmauth) but the client cluster don't have, the playbook will fail
+# as the owningcluster is in a array, we need to loop over or make list of the array to be able to use when:
+#
 - name: Client Cluster (access) | List the remote cluster already defined
   uri:
     validate_certs: "{{ validate_certs_uri }}"
@@ -266,7 +268,7 @@
       uri:
         validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -315,7 +317,7 @@
 #
 # adminNodeName section
 #
-    - name: scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+    - name: scale_remotemount_debug | Print out the array storing the adminNodeNames from the Storage Cluster (owning)
       debug:
         msg: "{{ owning_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -359,7 +361,7 @@
 #
 # deamonNodeName section
 #
-    - name: scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+    - name: scale_remotemount_debug | Print out the array storing the DeamonNodeNames from the Storage Cluster (owning)
       debug:
         msg: "{{ owning_daemon_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -384,7 +386,7 @@
           - 202
       register: daemonnodesname_uri_result
       run_once: True
-      when: scale_remotemount_storage_adminnodename is not true
+      when: not scale_remotemount_storage_adminnodename
 
     - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster with DeamonNodeName (JOB: {{ daemonnodesname_uri_result.json.jobs[0].jobId }})"
       uri:
@@ -399,7 +401,7 @@
       retries: "{{ restapi_retries_count }}"
       delay: "{{ restapi_retries_delay }}"
       run_once: True
-      when: scale_remotemount_storage_adminnodename is not true
+      when: not scale_remotemount_storage_adminnodename
   when:
     - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
@@ -474,7 +476,7 @@
   when:
    - 'item.item.scale_remotemount_storage_filesystem_name not in current_scale_remotemount_storage_filesystem_name'
 
-- name: Mount Filesystem | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster "{{ item.json.jobs.0['jobId'] }}"
+- name: Mount Filesystem | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster ##"{{ item.json.jobs.0['jobId'] }}"
   uri:
     validate_certs: "{{ validate_certs_uri }}"
     force_basic_auth: true

--- a/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
+++ b/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
@@ -21,7 +21,7 @@
   register: owning_cluster_info
   run_once: True
 
-- name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Storage Cluster (owner) | Print the Cluster Information
+- name: Remote Cluster Config - API-CLI |  Storage Cluster (owner) | scale_remotemount_debug | Print the Cluster Information
   debug:
     msg: "{{ owning_cluster_info }}"
   when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -34,7 +34,7 @@
   failed_when: false
   run_once: True
 
-- name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Client Cluster (access) | Print the Cluster Information
+- name: Remote Cluster Config - API-CLI | Client Cluster (access) | scale_remotemount_debug | Print the Cluster Information
   debug:
     msg: "{{ access_cluster_info }}"
   when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -116,31 +116,75 @@
   when:
     - (remote_clusters_results.status == 200) or (scale_remotemount_forceRun | bool)
 
+# Get node names and check if gpfs deamon is running.
 
+- name: Remote Cluster Config - API-CLI | Client Cluster (access) | GET the cluster nodes name information
+  shell: /usr/lpp/mmfs/bin/mmlscluster -Y | grep -v HEADER | grep clusterNode |  cut -d ':' -f 8
+  register: access_node_names
+  changed_when: false
+  failed_when: false
+  run_once: True
+
+- name: Remote Cluster Config - API-CLI | Client Cluster (access) | scale_remotemount_debug | Print the Cluster Information
+  debug:
+    msg: "{{ access_node_names.stdout_lines |  join(',') }}"
+  when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
+  run_once: True
+
+- set_fact:
+    accessing_nodes_name: []
+  run_once: True
+
+- set_fact:
+    accessing_nodes_name: "{{ access_node_names.stdout_lines |  join(',')  }}"
+  run_once: True
+
+- name: Remote Cluster Config - API-CLI | Client Cluster (access) | Check if GPFS deamon is started
+  shell: /usr/lpp/mmfs/bin/mmgetstate -Y -N {{ accessing_nodes_name }} | grep -v HEADER | cut -d ':' -f 9
+  register: gpfs_deamon_state
+  changed_when: false
+  run_once: true
+
+- name: Remote Cluster Config - API-CLI | Client Cluster (access) | Fail if GPFS deamon is not started
+  fail:
+    msg: "Scale/GPFS deamon is NOT running on one or serveral of your client cluster node. Check and run mmount manually"
+  when: "'down' in gpfs_deamon_state.stdout"
+  ignore_errors: true
+  run_once: true
+
+#
+# Section for doing the configuration of remote cluster.
+#
 - name: Remote Cluster Config - API-CLI | Exchange the keys between Storage and Client Clusters (access)
   block:
     - name: Step 3 - Remote Cluster Config - API-CLI
       debug:
         msg: "Configure remote Cluster connection between Storage Cluster (owner) and Client Cluster (access)"
       run_once: True
+      when:
+        - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
     - name: Remote Cluster Config - API-CLI | Remote Cluster connection status
       debug:
         msg: "Remote Cluster connection to ('{{ access_cluster_name }}') is not configured, procceding with configuration"
       run_once: True
+      when:
+        - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
     - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Get the Public key from CLI and register
       shell: "cat /var/mmfs/ssl/id_rsa_committed.pub"
       register: accesskey_result
       run_once: True
+      when:
+        - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
-    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results
+    - name: Remote Cluster Config - API-CLI |  Client Cluster (accesing) | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results
       debug:
         msg: "{{ accesskey_result }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
 
-    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results to file ("{{ scale_remote_mount_client_access_key }}")
+    - name: Remote Cluster Config - API-CLI | Client Cluster (accesing) | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results to file ("{{ scale_remote_mount_client_access_key }}")
       copy:
         dest: "{{ scale_remote_mount_client_access_key }}"
         content: "{{ accesskey_result }}\n"
@@ -169,6 +213,8 @@
           - 202
       register: send_key
       run_once: True
+      when:
+        - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
     - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | Check the result of adding the Client Cluster {{ send_key.json.jobs[0].jobId }}"
       uri:
@@ -183,6 +229,8 @@
       retries: "{{ restapi_retries_count }}"
       delay: "{{ restapi_retries_delay }}"
       run_once: True
+      when:
+        - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
     - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Get the Public Key
       uri:
@@ -229,7 +277,7 @@
       uri:
         validate_certs: "{{ validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -280,7 +328,7 @@
 #
 # adminNodeName section
 #
-    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the AdminNodeNames from the Storage Cluster (owning)
       debug:
         msg: "{{ owning_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -297,7 +345,7 @@
 #
 # deamonNodeName section
 #
-    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the nodes in the Storage Cluster (owning)
+    - name: Remote Cluster Config - API-CLI | scale_remotemount_debug | Print out the array storing the DeamonNodeNames from the Storage Cluster (owning)
       debug:
         msg: "{{ owning_daemon_nodes_name }}"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -310,7 +358,7 @@
       register: remote_cluster_add_ssh
       failed_when:
         - "remote_cluster_add_ssh.rc != 0 and 'is already defined' not in remote_cluster_add_ssh.stderr"
-      when: scale_remotemount_storage_adminnodename is not true
+      when: not scale_remotemount_storage_adminnodename
 
     - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Cleanup temporary keys.
       file:


### PR DESCRIPTION
1. Fixed some logic when remote-mount is halfway set up between client and storage.

2. When adding the storage Cluster as a remote cluster in the client cluster we need to specify what nodes should be used as contact nodes, and in normal cases, all nodes would be fine. In case we have AFM Gateway nodes, or Cloud nodes TCT, we want to use the REST API filter to remove those nodes, so they are not used.

3. Checks that GPFS daemon is started on GUI node, it will check the first server in NodeClass GUI_MGMT_SERVERS, this is the same flag to check when trying to mount up filesystems on all nodes. The check can be disabled by changing the flag to false.

4. By default the role will try to mount the filesystem on all client cluster (accessing) nodes, So added a function to add a comma-separated list of servers. example: scale1-test,scale2-test

5. Minor fixes in the role. like When: changes in ansible versions. 

Signed-off-by: Ole Kristian <ole.kr.myklebust@gmail.com>