### PR TITLE
More improvements in RemoteMount role. 

### DIFF
--- a/roles/remotemount_configure/defaults/main.yml
+++ b/roles/remotemount_configure/defaults/main.yml
@@ -4,19 +4,20 @@ scale_remotemount_debug: false
 scale_remotemount_forceRun: false
 
 # retries - 2 minutes (40 x 3 seconds)
-restapi_retries_count: 40
-restapi_retries_delay: 3
+scale_remotemount_restapi_retries_count: 40
+scale_remotemount_restapi_retries_delay: 3
 
-client_cluster_gui_port: 443
-storage_cluster_gui_port: 443
+scale_remotemount_client_cluster_gui_port: 443
+scale_remotemount_storage_cluster_gui_port: 443
 
-scalemgmt_endpoint: "scalemgmt/v2"
-remote_mount_endpoint: "{{ scalemgmt_endpoint }}/remotemount"
+scale_remotemount_scalemgmt_endpoint: "scalemgmt/v2"
+scale_remotemount_endpoint: "{{ scale_remotemount_scalemgmt_endpoint }}/remotemount"
 
-validate_certs_uri: 'no'
+
+scale_remotemount_validate_certs_uri: 'no'
 
 # Temporary Storage for Public Key, Only used when debuging
-scale_remote_mount_client_access_key: /tmp/client_cluster.pub
+scale_remotemount_client_access_key: /tmp/client_cluster.pub
 
 # Sets the security mode for communications between the current cluster and the remote cluster
 # Encyption can have performance effect and increased CPU usage
@@ -28,7 +29,7 @@ scale_remote_mount_client_access_key: /tmp/client_cluster.pub
 #        AES256-SHA256
 
 # AES128-SHA', 'AES256-SHA' , AUTHONLY
-remotecluster_chipers: "AUTHONLY"
+scale_remotemount_remotecluster_chipers: "AUTHONLY"
 
 # Storage filesystem
 # scale_remotemount_access_mount_attributes: "rw"

--- a/roles/remotemount_configure/tasks/cleanup_filesystems.yml
+++ b/roles/remotemount_configure/tasks/cleanup_filesystems.yml
@@ -1,26 +1,27 @@
 ---
 - name: "Cleanup | Client Cluster (access) | Check if the remotefilesystem is already defined {{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_filesystem_results
   ignore_errors: true
   run_once: True
 
 - name: "Cleanup | Client Cluster (access) | Remove defined filesystem {{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}"
   block:
-    - name: "Client Cluster (access) | Unmount the filesystem | PUT {{ scalemgmt_endpoint }}/filesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}/unmount"
+    - name: "Client Cluster (access) | Unmount the filesystem | PUT {{ scale_remotemount_scalemgmt_endpoint }}/filesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}/unmount"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/filesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}/unmount
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/filesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}/unmount
         method: PUT
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -36,22 +37,22 @@
 
     - name: "Checking results from the job: {{ umount_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ umount_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
 
-    - name: "Client Cluster (access) | Delete the filesystem | DELETE {{ remote_mount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}?force=yes"
+    - name: "Client Cluster (access) | Delete the filesystem | DELETE {{ scale_remotemount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}?force=yes"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}?force=yes
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remotefilesystems/{{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}?force=yes
         method: DELETE
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -61,15 +62,22 @@
 
     - name: "Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
-  when: not remote_filesystem_results.failed
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
+  when: remote_filesystem_results.json.status.code == 200
   run_once: True
+
+- name: "Cleanup | Client Cluster (access) | Output from remove defined filesystem {{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}"
+  run_once: True
+  debug:
+    msg: "The is no filesystem named ({{ cleanup_filesystem_loop.scale_remotemount_client_filesystem_name }}) - Message from Restapi: {{ remote_filesystem_results.json.status.message }}"
+  when:
+    - remote_filesystem_results.json.status.code == 400

--- a/roles/remotemount_configure/tasks/cleanup_remote_mount.yml
+++ b/roles/remotemount_configure/tasks/cleanup_remote_mount.yml
@@ -3,9 +3,9 @@
 #
 - name: Cleanup | Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -23,9 +23,9 @@
 
 - name: Cleanup | Client Cluster (access) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
@@ -69,16 +69,16 @@
 
 - name: Cleanup | Client Cluster (access) | List the remote cluster already defined
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
   register: remote_clusters_result
   run_once: True
 
-- name: Cleanup | scale_remotemount_debug | Print out the remote clusters
+- name: Cleanup | Client Cluster (access) | scale_remotemount_debug | Print out the remote clusters message code from RestAPI.
   debug:
     msg: "{{ remote_clusters_result.json }}"
   when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
@@ -86,7 +86,7 @@
 
 # The remote_clusters_results is in an array, so looping here incase there are multiple remote clusters
 # We want to delete the one where the owningCluster name matches what we are trying to do a remote mount on
-- name: Cleanup | Delete the clusters on a loop...
+- name: Cleanup | Client Cluster (access) | Delete the Remote Mount/clusters connection on a loop.
   include_tasks: delete_remote_cluster.yml
   when: item.owningCluster == owning_cluster_name
   loop: "{{ remote_clusters_result.json.owningClusters }}"
@@ -98,26 +98,27 @@
 
 - name: "Cleanup | Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_clusters_results
   ignore_errors: true
   run_once: True
 
 - name: Cleanup | Storage Cluster (owner) | Delete the Client Cluster, if it exists
   block:
-    - name: "DELETE: {{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
+    - name: "DELETE: {{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -127,15 +128,23 @@
 
     - name: "Cleanup | Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
-  when: not remote_clusters_results.failed
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
+  #when: not remote_clusters_results.failed
+  when: remote_clusters_results.json.status.code == 200
   run_once: True
+
+- name: "Cleanup | Storage Cluster (owner) | Output from delete the Client Cluster, ('{{ access_cluster_name }}')"
+  run_once: True
+  debug:
+    msg: "The is no Client/Accessing cluster named: ({{ access_cluster_name }}) - Message from RestAPI: {{ remote_clusters_results.json.status.message }}"
+  when:
+    - remote_clusters_results.json.status.code == 400

--- a/roles/remotemount_configure/tasks/cleanup_remote_mount_api_cli.yml
+++ b/roles/remotemount_configure/tasks/cleanup_remote_mount_api_cli.yml
@@ -3,9 +3,9 @@
 #
 - name: Cleanup Remote Mount - API-CLI | Storage Cluster (owner) | GET the Owning Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -125,15 +125,16 @@
 
 - name: "Cleanup Remote Mount - API-CLI | Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_clusters_results
   ignore_errors: true
   run_once: True
@@ -141,11 +142,11 @@
 
 - name: Cleanup Remote Mount - API-CLI | Storage Cluster (owner) | Delete the Client Cluster, if it exists.
   block:
-    - name: "DELETE: {{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
+    - name: "DELETE: {{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -155,15 +156,22 @@
 
     - name: "Cleanup Remote Mount - API-CLI | Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
-  when: not remote_clusters_results.failed
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
+  when: remote_clusters_results.json.status.code == 200
   run_once: True
+
+- name: "Cleanup Remote Mount - API-CLI | Storage Cluster (owner) | Output from delete the Client Cluster, ('{{ access_cluster_name }}')"
+  run_once: True
+  debug:
+    msg: "The is no Client/Accessing cluster named: ({{ access_cluster_name }}) - Message from RestAPI: {{ remote_clusters_results.json.status.message }}"
+  when:
+    - remote_clusters_results.json.status.code == 400

--- a/roles/remotemount_configure/tasks/delete_remote_cluster.yml
+++ b/roles/remotemount_configure/tasks/delete_remote_cluster.yml
@@ -4,9 +4,9 @@
 #  Only users with role 'Administrator' or 'CNSS Operator' have permission to for this REST endpoint. Read also the documentation of CLI command 'mmremotecluster delete'.
 - name: Client Cluster (access) | DELETE The remotecluster {{ owning_cluster_name }} ...
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters/{{ owning_cluster_name }}
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters/{{ owning_cluster_name }}
     method: DELETE
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
@@ -16,13 +16,13 @@
 
 - name: Client Cluster (access) | Check the results from the DELETE
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
-  retries: "{{ restapi_retries_count }}"
-  delay: "{{ restapi_retries_delay }}"
+  retries: "{{ scale_remotemount_restapi_retries_count }}"
+  delay: "{{ scale_remotemount_restapi_retries_delay }}"

--- a/roles/remotemount_configure/tasks/main.yml
+++ b/roles/remotemount_configure/tasks/main.yml
@@ -36,9 +36,9 @@
 - block: # RESTAPI - when: scale_remotemount_client_no_gui == false
     - name: Main | Storage Cluster (owner) | Check Connectivity to Storage Cluster GUI
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -73,9 +73,9 @@
 
     - name: Main | Client Cluster (access) | Check Connectivity to Client Cluster GUI
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -110,9 +110,9 @@
 
     - name: Main | Client Cluster (access) | Check status of GPFS deamon (Nodeclass GUI_MGMT_SERVERS)
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -120,6 +120,7 @@
         return_content: yes
         status_code:
           - 200
+          - 400
       register: clientcluster_gpfs_deamon_status
       run_once: True
       when: scale_remotemount_gpfsdemon_check | bool
@@ -128,26 +129,26 @@
       run_once: True
       ignore_errors: true
       debug:
-        msg: "{{ clientcluster_gpfs_deamon_status.json.states[0].state }}"
+        msg: "Status of GPFS Deamon: {{ clientcluster_gpfs_deamon_status.json.states[0].state }} - Rest API status message: {{ clientcluster_gpfs_deamon_status.json.status.message }}"
       when:
         - scale_remotemount_gpfsdemon_check | bool
         - scale_remotemount_debug is defined
         - scale_remotemount_debug | bool
 
-    - name: Main | Client Cluster (access) | GPFS Deamon on Client Cluster is down (Nodeclass GUI_MGMT_SERVERS)
+    - name: Main | Client Cluster (access) | GPFS Deamon on Client Cluster (Nodeclass GUI_MGMT_SERVERS)
       run_once: True
       assert:
         that:
-          - "'HEALTHY' or 'DEGRADED' in storagecluster_gpfs_deamon_status.json.states[0].state"
+          - "'HEALTHY' or 'DEGRADED' in clientcluster_gpfs_deamon_status.json.states[0].state"
         fail_msg: "'GPFS Deamon is NOT started on NodeClass GUI_MGMT_SERVERS"
         success_msg: "'GPFS Deamon is started on NodeClass GUI_MGMT_SERVERS"
       when: scale_remotemount_gpfsdemon_check | bool
 
     - name: Main | Storage Cluster (owning) | Check status of gpfs deamon on GUI_MGMT_SERVERS
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -155,6 +156,7 @@
         return_content: yes
         status_code:
           - 200
+          - 400
       register: storagecluster_gpfs_deamon_status
       run_once: True
       when: scale_remotemount_gpfsdemon_check | bool
@@ -169,7 +171,7 @@
         - scale_remotemount_debug is defined
         - scale_remotemount_debug | bool
 
-    - name: Main | Storage Cluster (owning) | GPFS Deamon on Storage Cluster is down (Nodeclass GUI_MGMT_SERVERS)
+    - name: Main | Storage Cluster (owning) | GPFS Deamon on Storage Cluster (Nodeclass GUI_MGMT_SERVERS)
       run_once: True
       assert:
         that:
@@ -195,9 +197,9 @@
 - block: # RESTAPI-CLI when: scale_remotemount_client_no_gui == true
   - name: Main | API-CLI | Storage Cluster (owner) | Check Connectivity to Storage Cluster GUI
     uri:
-      validate_certs: "{{ validate_certs_uri }}"
+      validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
       force_basic_auth: yes
-      url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+      url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
       method: GET
       user: "{{ scale_remotemount_storage_gui_username }}"
       password: "{{ scale_remotemount_storage_gui_password }}"
@@ -232,9 +234,9 @@
 
   - name: Main | API-CLI | Storage Cluster (owning) | Check status of gpfs deamon on GUI_MGMT_SERVERS
     uri:
-      validate_certs: "{{ validate_certs_uri }}"
+      validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
       force_basic_auth: true
-      url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
+      url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/GUI_MGMT_SERVERS/health/states?fields=component%2Cstate&filter=component%3DGPFS%2C
       method: GET
       user: "{{ scale_remotemount_storage_gui_username }}"
       password: "{{ scale_remotemount_storage_gui_password }}"

--- a/roles/remotemount_configure/tasks/mount_filesystem_api_cli.yml
+++ b/roles/remotemount_configure/tasks/mount_filesystem_api_cli.yml
@@ -9,9 +9,9 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -52,14 +52,14 @@
 
 - name: Step 5 - Mount Filesystem - Rest-API
   debug:
-    msg: "On Storage Cluster, Check if filesystems is allready accessible for Client Cluster"
+    msg: "On Storage Cluster, Check if filesystems is already accessible for Client Cluster"
   run_once: True
 
-- name: "Mount Filesystem - Rest-API | Storage Cluster (owner) | Check if filesystems is allready accessible for Client Cluster  ('{{ access_cluster_name }}')"
+- name: "Mount Filesystem - Rest-API | Storage Cluster (owner) | Check if filesystems is already accessible for Client Cluster  ('{{ access_cluster_name }}')"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -92,9 +92,9 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owning) | Allow and Set the client cluster filesystem access attributes on the Storage Cluster
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
     method: POST
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -121,16 +121,16 @@
 
 - name: Mount Filesystem - Rest-API | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster ##"{{ completed_check.json.jobs[0].jobId }}"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
-  retries: "{{ restapi_retries_count }}"
-  delay: "{{ restapi_retries_delay }}"
+  retries: "{{ scale_remotemount_restapi_retries_count }}"
+  delay: "{{ scale_remotemount_restapi_retries_delay }}"
   run_once: True
   loop: "{{ uri_result.results }}"
   when:
@@ -214,9 +214,9 @@
   when: "'down' in gpfs_deamon_state.stdout"
   run_once: true
 
-# Not adding any check here, run only when when mmremotefs add task is also run.
+# Not adding any check here, runs only when when mmremotefs add task is also run.
 
-- name: Client Cluster (access) | Mount remote filesystem on all client nodes - Output is from previous task, check if the filesystem's is allready mounted
+- name: Client Cluster (access) | Mount remote filesystem on all client nodes - Output is from previous task, checks if the filesystem's is already mounted
   run_once: True
   command: /usr/lpp/mmfs/bin/mmmount {{ item.item.scale_remotemount_client_filesystem_name }} -N {{ scale_remotemount_client_mount_on_nodes | default('all') }}
   loop: "{{ remote_filesystem_results_cli.results }}"
@@ -230,7 +230,7 @@
 
 # Adding a stdout from previous as the stdout from the loop abow can be confusing when several loops.
 
-- name:  Client Cluster (access) | Mount remote filesystem on all client nodes - Shows stdout from the previous task.
+- name:  Client Cluster (access) | Mount remote filesystem on all client nodes - shows stdout from the previous task.
   debug:
     msg: "Message from mount remote filesystem task: {{ item }}"
   loop: "{{ client_cluster_mount_remotefs | json_query('results[*].stdout') }}"

--- a/roles/remotemount_configure/tasks/mount_filesystems.yml
+++ b/roles/remotemount_configure/tasks/mount_filesystems.yml
@@ -11,9 +11,9 @@
 #
 - name: Client Cluster (access) | Check status of GPFS deamon on all nodes before mounting filesystem.
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/%3Aall%3A/health/states?fields=component%2Cstate&filter=component%3DGPFS%2Cstate%3DFAILED
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/%3Aall%3A/health/states?fields=component%2Cstate&filter=component%3DGPFS%2Cstate%3DFAILED
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
@@ -52,15 +52,16 @@
 
 - name: Client Cluster (access) | Check if the remotefilesystem is already defined
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems/{{ filesystem_loop.scale_remotemount_client_filesystem_name }}
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remotefilesystems/{{ filesystem_loop.scale_remotemount_client_filesystem_name }}
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_filesystem_results
   ignore_errors: true
   run_once: True
@@ -74,9 +75,9 @@
 
     - name: Client Cluster (access) | Create the remotefs and then mount the filesystem
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/remotefilesystems
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remotefilesystems
         method: POST
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -98,16 +99,16 @@
 
     - name: "Client Cluster (access) | Check the result of adding the remotefs and mounting the filesystem (JOB: {{ send_key.json.jobs[0].jobId }})"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
 
   when: (remote_filesystem_results.status == 400)

--- a/roles/remotemount_configure/tasks/remotecluster.yml
+++ b/roles/remotemount_configure/tasks/remotecluster.yml
@@ -9,9 +9,9 @@
 
 - name: Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -29,9 +29,9 @@
 
 - name: Client Cluster (access) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
@@ -76,28 +76,29 @@
 #
 - name: "Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_clusters_results
   ignore_errors: true
   run_once: True
 
 #
-# TODO: there is no Check if the Storage Cluster (Owner) is allready defined on Client Cluster, so in some cases where storage cluster have connection to client cluster (mmauth) but the client cluster don't have, the playbook will fail
+# TODO: there is no Check if the Storage Cluster (Owner) is already defined on Client Cluster, so in some cases where storage cluster have connection to client cluster (mmauth) but the client cluster don't have, the playbook will fail
 # as the owningcluster is in a array, we need to loop over or make list of the array to be able to use when:
 #
 - name: Client Cluster (access) | List the remote cluster already defined
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+    url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters
     method: GET
     user: "{{ scale_remotemount_client_gui_username }}"
     password: "{{ scale_remotemount_client_gui_password }}"
@@ -126,11 +127,11 @@
 
 - name: Storage Cluster (owner) | Delete the Client Cluster, if it exists
   block:
-    - name: "DELETE: {{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
+    - name: "DELETE: {{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -140,16 +141,16 @@
 
     - name: "Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
   when: not remote_clusters_results.failed and scale_remotemount_forceRun | bool
   run_once: True
 
@@ -162,9 +163,9 @@
 
     - name: Client Cluster (access) | Get the Public Key
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/authenticationkey
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -182,9 +183,9 @@
 
     - name: Storage Cluster (owner) | Send the Public Key of the Client Cluster (access)
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters
         method: POST
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -192,6 +193,7 @@
         body: |
           {
             "remoteCluster": "{{ access_cluster_name }}",
+            "ciphers": ["{{ scale_remotemount_remotecluster_chipers }}"],
             "key": {{ accesskey_result.json.key | trim | replace(", ", ",") }}
           }
         status_code:
@@ -201,16 +203,16 @@
 
     - name: "Storage Cluster (owner) | Check the result of adding the Client Cluster {{ send_key.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status != "FAILED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
 
     #
@@ -219,9 +221,9 @@
 
     - name: Storage Cluster (owner) | Get the Public Key
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/authenticationkey
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -244,9 +246,9 @@
 
     - name: Client Cluster (access) | List the remote cluster already defined
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -264,11 +266,11 @@
 #
 # This section is to gather the nodenames and adminNodeName
 #
-    - name: "Storage Cluster (owning) | GET AdminNodeNames Info - GET {{ scalemgmt_endpoint }}/nodes"
+    - name: "Storage Cluster (owning) | GET AdminNodeNames Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -290,11 +292,11 @@
 #
 # This Section is when using daemonNodeName
 #
-    - name: "Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scalemgmt_endpoint }}/nodes/"
+    - name: "Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes/"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/{{item}}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{item}}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -325,9 +327,9 @@
 
     - name: Client Cluster (access) | Add Storage Cluster as a Remote Cluster with adminNodeName
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters
         method: POST
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -346,16 +348,16 @@
 
     - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster with adminNodeName (JOB: {{ adminnode_uri_result.json.jobs[0].jobId }})"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ adminnode_uri_result.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ adminnode_uri_result.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
       when: scale_remotemount_storage_adminnodename is defined and scale_remotemount_storage_adminnodename | bool
 #
@@ -369,9 +371,9 @@
 
     - name: Client Cluster (access) | Add Storage Cluster as a Remote Cluster with DeamonNodeName
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ remote_mount_endpoint }}/owningclusters
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/owningclusters
         method: POST
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
@@ -390,16 +392,16 @@
 
     - name: "Client Cluster (access) | Check the result of adding the remote Storage Cluster with DeamonNodeName (JOB: {{ daemonnodesname_uri_result.json.jobs[0].jobId }})"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ client_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ daemonnodesname_uri_result.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_client_gui_hostname }}:{{ scale_remotemount_client_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ daemonnodesname_uri_result.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_client_gui_username }}"
         password: "{{ scale_remotemount_client_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
       when: not scale_remotemount_storage_adminnodename
   when:
@@ -407,14 +409,14 @@
 
 - name: Step 5 - Configure and Mount filesystems
   debug:
-    msg: "On Storage Cluster, Check if filesystems is allready accessible for Client Cluster"
+    msg: "On Storage Cluster, Check if filesystems is already accessible for Client Cluster"
   run_once: True
 
-- name: "Mount Filesystem | Storage Cluster (owner) | Check if filesystems is allready accessible for Client Cluster  ('{{ access_cluster_name }}')"
+- name: "Mount Filesystem | Storage Cluster (owner) | Check if filesystems is already accessible for Client Cluster  ('{{ access_cluster_name }}')"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -449,9 +451,9 @@
 
 - name: Mount Filesystem| Storage Cluster (owning) | Allow and Set the client cluster filesystem access attributes on the Storage Cluster
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}/access/{{ item.scale_remotemount_storage_filesystem_name }}
     method: POST
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -478,16 +480,16 @@
 
 - name: Mount Filesystem | Storage Cluster (owning) | Check the result of setting the access attributes on the Storage Cluster ##"{{ item.json.jobs.0['jobId'] }}"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: true
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ item.json.jobs.0['jobId'] }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
   register: completed_check
   until: completed_check.json.jobs[0].status == "COMPLETED"
-  retries: "{{ restapi_retries_count }}"
-  delay: "{{ restapi_retries_delay }}"
+  retries: "{{ scale_remotemount_restapi_retries_count }}"
+  delay: "{{ scale_remotemount_restapi_retries_delay }}"
   run_once: True
   loop: "{{ uri_result.results }}"
   when:

--- a/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
+++ b/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
@@ -9,9 +9,9 @@
 
 - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET the Cluster Information
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/cluster
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
@@ -53,19 +53,20 @@
 
 - name: Step 2 - Remote Cluster Config - API-CLI
   debug:
-    msg: "Check if the Remote Cluster is allready configured"
+    msg: "Check if the Remote Cluster is already configured"
 
 - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
-    validate_certs: "{{ validate_certs_uri }}"
+    validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
     force_basic_auth: yes
-    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+    url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
     user: "{{ scale_remotemount_storage_gui_username }}"
     password: "{{ scale_remotemount_storage_gui_password }}"
     body_format: json
     status_code:
       - 200
+      - 400
   register: remote_clusters_results
   ignore_errors: true
   run_once: true
@@ -80,11 +81,11 @@
 
 - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Delete the Client Cluster, if it exists
   block:
-    - name: "DELETE: {{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
+    - name: "DELETE: {{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters/{{ access_cluster_name }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -95,16 +96,16 @@
 
     - name: "Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status == "COMPLETED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
   when:
     - not remote_clusters_results.failed and scale_remotemount_forceRun | bool
@@ -184,9 +185,9 @@
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
 
-    - name: Remote Cluster Config - API-CLI | Client Cluster (accesing) | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results to file ("{{ scale_remote_mount_client_access_key }}")
+    - name: Remote Cluster Config - API-CLI | Client Cluster (accesing) | scale_remotemount_debug | Print out the Client Cluster (access) Public Key results to file ("{{ scale_remotemount_client_access_key }}")
       copy:
-        dest: "{{ scale_remote_mount_client_access_key }}"
+        dest: "{{ scale_remotemount_client_access_key }}"
         content: "{{ accesskey_result }}\n"
       when: scale_remotemount_debug is defined and scale_remotemount_debug | bool
       run_once: True
@@ -196,9 +197,9 @@
 
     - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Send the Public Key of the Client Cluster (access) to Storage Cluster (Owner)
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/remoteclusters
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters
         method: POST
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -206,7 +207,7 @@
         body: |
           {
             "remoteCluster": "{{ access_cluster_name }}",
-            "ciphers": ["{{ remotecluster_chipers }}"],
+            "ciphers": ["{{ scale_remotemount_remotecluster_chipers }}"],
             "key": {{ accesskey_result.stdout_lines }}
           }
         status_code:
@@ -218,25 +219,25 @@
 
     - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | Check the result of adding the Client Cluster {{ send_key.json.jobs[0].jobId }}"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: true
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
       register: completed_check
       until: completed_check.json.jobs[0].status != "FAILED"
-      retries: "{{ restapi_retries_count }}"
-      delay: "{{ restapi_retries_delay }}"
+      retries: "{{ scale_remotemount_restapi_retries_count }}"
+      delay: "{{ scale_remotemount_restapi_retries_delay }}"
       run_once: True
       when:
         - (remote_clusters_results.status == 400) or (scale_remotemount_forceRun | bool)
 
     - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Get the Public Key
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ remote_mount_endpoint }}/authenticationkey/
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/authenticationkey/
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -273,11 +274,11 @@
 #
 # This Section is gather the nodenames and adminNodeName
 #
-    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET adminNodeName Info - GET {{ scalemgmt_endpoint }}/nodes"
+    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET adminNodeName Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -299,11 +300,11 @@
 #
 # This Section is when using daemonNodeName
 #
-    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scalemgmt_endpoint }}/nodes/"
+    - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes/"
       uri:
-        validate_certs: "{{ validate_certs_uri }}"
+        validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ storage_cluster_gui_port }}/{{ scalemgmt_endpoint }}/nodes/{{item}}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{item}}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"


### PR DESCRIPTION
- Updated all variables to start with `scale_remotemount*`
- Added option for encrypting traffic between remote cluster and storage cluster 🔑 
- changed some when: to read restapi error code insted of a failed task.
- Updated tasks that do check to not output errors on 400 and 200.  Users don't get red/errors in a run 🦺 🧷  . 
- Added message to the user when there is notting to clean up, like cluster connection and filesystem. 
- Cleaned up some more typo and text wording. (endless work 🏫 ) 

Signed-off-by: Ole Kristian <ole.kr.myklebust@gmail.com>