### PR TITLE
 Add step to wait until GUI is up and running

### DIFF
--- a/roles/gui_configure/tasks/configure.yml
+++ b/roles/gui_configure/tasks/configure.yml
@@ -15,7 +15,16 @@
     name: gpfsgui
     state: started
     enabled: true
+    no_block: true
   when: scale_cluster_gui | bool
+
+# Verify GUI is up and running
+- name: Wait until gpfsgui is up and running
+  shell: "systemctl is-active gpfsgui"
+  register: systemctl_out
+  until: systemctl_out.stdout == "active"
+  retries: 10
+  delay: 20
 
 #
 # Initialize the GUI so that user dont need to wait and HTTPs certificate and be imported.

--- a/roles/nfs_install/tasks/install_local_pkg.yml
+++ b/roles/nfs_install/tasks/install_local_pkg.yml
@@ -361,6 +361,7 @@
   with_items:
   - "{{ scale_install_gpfs_nfs_python.files }}"
   - "{{ scale_install_gpfs_nfs_doc.files }}"
+  - "{{ scale_install_gpfs_nfs_gpfs.files }}"
   when: ansible_distribution in scale_ubuntu_distribution
 
 - name: install | Add GPFS package to list


### PR DESCRIPTION
 Ansible failed, when two GUI's are installed and started.

 Signed-off-by: Christoph Keil <chkeil@de.ibm.com>