### PR TITLE
Fix Ansible 2.10 deprecation warning

### DIFF
--- a/roles/core_common/tasks/check.yml
+++ b/roles/core_common/tasks/check.yml
@@ -91,15 +91,15 @@
 
 # set dynamic variable based on supported OS
 - name: check | Set variables based on yum/dnf based OS
-  include: yum/set_vars.yml
+  include_tasks: yum/set_vars.yml
   when: ansible_distribution in scale_rhel_distribution
 
 - name: check | Set variables based on apt based os
-  include: apt/set_vars.yml
+  include_tasks: apt/set_vars.yml
   when: ansible_distribution in scale_ubuntu_distribution
 
 - name: check | Set variables based on zypper based OS
-  include: zypper/set_vars.yml
+  include_tasks: zypper/set_vars.yml
   when: ansible_distribution in scale_sles_distribution
 
 # Copy and import gpg key on RHEL and SLES if gpfs version >= 5.0.5.0


### PR DESCRIPTION
Running the project with `ansible-core` 2.10 or later produces the following warning:

```shell
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. See 
https://docs.ansible.com/ansible-core/latest/user_guide/playbooks_reuse_includes.html for details. This feature will 
be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```

This change globally replaces the `include:` keyword with `include_tasks:`. This eliminates the warning.