### PR TITLE
Modernize wait-for-server handler

### DIFF
--- a/roles/core_prepare/handlers/main.yml
+++ b/roles/core_prepare/handlers/main.yml
@@ -23,11 +23,7 @@
   ignore_errors: true
 
 - name: wait-for-server
-  wait_for:
-    host: "{{ ansible_default_ipv4.address }}"
-    port: 22
-    state: started
+  wait_for_connection:
     delay: 45
     timeout: 300
   delegate_to: localhost
-# handlers file for precheck


### PR DESCRIPTION
The existing `wait-for-server` handler, which waits for the managed host to come back online after a reboot, doesn't work in all cases. It uses the generic `wait_for` module ([link](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/wait_for_module.html)) and checks the "default" IPv4 address. Depending on the specific setup this may or may not be appropriate... default IPv4 address might be a private address unreachable by the Ansible control node.

As an alternative there's the `wait_for_connection` module ([link](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/wait_for_connection_module.html)) built for this exact use case. It checks the IP address Ansible uses to connect to the node in the first place... eliminating the risk of choosing a private address unreachable by the control node.

This change replaces the module used by the `wait-for-server` handler to the more robust implementation, which works in all cases.