### PR TITLE
Add hosts to groups using their inventory_hostname

### DIFF
--- a/roles/core_configure/tasks/removenode.yml
+++ b/roles/core_configure/tasks/removenode.yml
@@ -1,7 +1,7 @@
 ---
 - name: delete | Initialize delete nodes
   add_host:
-    name: "{{ hostvars[item]['ansible_fqdn'] }}"
+    name: "{{ item }}"
     groups: scale_remove_nodes
   when:
     - hostvars[item].scale_state is defined and hostvars[item].scale_state == 'absent'
@@ -29,7 +29,7 @@
 
     - name: delete | Set delete node
       set_fact:
-        delete_nodes: "{{ groups['scale_remove_nodes'] | list }}"
+        delete_nodes: "{{ groups['scale_remove_nodes'] | map('extract', hostvars, 'scale_daemon_nodename') | list }}"
 
     - name: delete | Delete an IBM Spectrum Scale Node from Cluster
       ibm_spectrumscale_node:

--- a/roles/gui_configure/tasks/main.yml
+++ b/roles/gui_configure/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: check | Check gui nodes if defined
   add_host:
-    name: "{{ hostvars[item]['inventory_hostname'] }}"
+    name: "{{ item }}"
     groups: scale_gui_defined_listnodes
   when:
      - hostvars[item].scale_cluster_gui is defined

--- a/roles/gui_prepare/tasks/inventory_check.yml
+++ b/roles/gui_prepare/tasks/inventory_check.yml
@@ -2,7 +2,7 @@
 
 - name: check | Check gui node
   add_host:
-    name: "{{ hostvars[item]['ansible_fqdn'] }}"
+    name: "{{ item }}"
     groups: scale_gui_nodes
   when:
      - hostvars[item].scale_cluster_gui is defined
@@ -34,7 +34,7 @@
 - block:
    - name: check | initialize existing gui nodes
      set_fact:
-       inventory_gui_nodes: "{{ groups['scale_gui_nodes'] | list }}"
+       inventory_gui_nodes: "{{ groups['scale_gui_nodes'] | map('extract', hostvars, 'scale_daemon_nodename') | list }}"
        existing_gui_nodes: "{{ scale_config_existing_guinode.stdout.split(',') }}"
      when:
        - scale_config_existing_guinode.stdout_lines | length > 0


### PR DESCRIPTION
When adding hosts to groups, one should always use the host's `inventory_hostname` - i.e. the name of the host as it is listed in the inventory. This might be the same as the host's FQDN, but it could also be something completely different. One can not rely on the inventory name being the host's FQDN.

We had similar problems before, see #577 for details...

When the inventory name of a host is different from it's FQDN, running this projects leads to all sorts of strange errors... such as the following:

```shell
TASK [ibm.spectrum_scale.gui_prepare : check | Check if gui is enabled] ********************************************
Dienstag 14 März 2023  16:03:18 +0100 (0:00:00.242)       0:07:50.262 ********* 
fatal: [g1-node1]: FAILED! => 
  msg: |-
    The conditional check '(hostvars[item].scale_cluster_gui is defined and (true in ansible_play_hosts | map('extract', hostvars, 'scale_cluster_gui') | map('bool') | list))' failed. The error was: error while evaluating conditional ((hostvars[item].scale_cluster_gui is defined and (true in ansible_play_hosts | map('extract', hostvars, 'scale_cluster_gui') | map('bool') | list))): 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'scale_cluster_gui'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'scale_cluster_gui'
  
    The error appears to be in '.../roles/gui_prepare/tasks/inventory_check.yml': line 13, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: check | Check if gui is enabled
      ^ here
```

This change fixes all `add_host` tasks to consistently use the `inventory_hostname`, and then extract each host's `scale_daemon_nodename` where required...