### PR TITLE
D-320760:Validation for jar folder (opt/hadoop/jars) and jars is required at deploy pre-check

### DIFF
--- a/roles/hdfs_prepare/tasks/java_home.yml
+++ b/roles/hdfs_prepare/tasks/java_home.yml
@@ -62,6 +62,12 @@
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - javahome_path|length > 0
 
+- fail:
+    msg: "JAVA_HOME not set properly"
+  when: 
+    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - jvm_list.rc != 0
+    
 - name: check | Fetch hdfs extracted tar
   set_fact:
      hdfs_dependency_jars_dir: "hadoop-3.2.4"
@@ -85,9 +91,3 @@
   when:
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - dep_jars.rc != 0
-
-- fail:
-    msg: "JAVA_HOME not set properly"
-  when: 
-    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
-    - jvm_list.rc != 0

--- a/roles/hdfs_prepare/tasks/java_home.yml
+++ b/roles/hdfs_prepare/tasks/java_home.yml
@@ -62,6 +62,30 @@
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - javahome_path|length > 0
 
+- name: check | Fetch hdfs extracted tar
+  set_fact:
+     hdfs_dependency_jars_dir: "hadoop-3.2.4"
+  when:
+    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - transparency_322_enabled|bool
+
+- debug:
+    msg: "hdfs_dependency_jars_dir: {{ hdfs_dependency_jars_dir }}"
+
+- name: check | verify dependency jars
+  command: "ls /opt/hadoop/jars/{{ hdfs_dependency_jars_dir }}"
+  register: dep_jars
+  when: ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+
+- debug:
+    msg: "dep_jars: {{ dep_jars }}"
+
+- fail:
+    msg: "Dependency jars not exist in /opt/hadoop/jars directory."
+  when:
+    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - dep_jars.rc != 0
+
 - fail:
     msg: "JAVA_HOME not set properly"
   when: 

--- a/roles/hdfs_prepare/tasks/java_home.yml
+++ b/roles/hdfs_prepare/tasks/java_home.yml
@@ -58,22 +58,42 @@
 - name: check | verify JAVA
   command: "ls {{ javahome_path }}/bin/java"
   register: jvm_list
-  when: 
+  when:
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - javahome_path|length > 0
 
 - fail:
     msg: "JAVA_HOME not set properly"
-  when: 
+  when:
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - jvm_list.rc != 0
-    
+
 - name: check | Fetch hdfs extracted tar
   set_fact:
-     hdfs_dependency_jars_dir: "hadoop-3.2.4"
+     hdfs_dependency_jars_dir: "hadoop-3.1.4"
+
+- name: Check and fetch gpfs.hdfs-protocol version
+  shell: "rpm -q gpfs.hdfs-protocol --qf %{VERSION}-%{RELEASE}"
+  register: gpfs_hdfs_protocol_version
   when:
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
     - transparency_322_enabled|bool
+  ignore_errors: true
+
+- debug:
+    msg: "gpfs_hdfs_protocol_version: {{ gpfs_hdfs_protocol_version.stdout_lines[0] }}"
+
+- name: Check gpfs.hdfs-protocol version for standalone installation
+  fail:
+    msg: >
+      "Standalone installation of gpfs.hdfs-protocol version is not supported. It can only be upgraded"
+      " from gpfs.hdfs-protocol version 3.2.2-5. For additional information, refer to the documentation available at the following link:"
+      " https://www.ibm.com/docs/en/storage-scale-bda?topic=hdfs-setup-transparency-cluster."
+  when:
+    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - transparency_322_enabled|bool
+    - gpfs_hdfs_protocol_version.rc == 0
+    - gpfs_hdfs_protocol_version.stdout_lines[0] < '3.2.2-5'
 
 - debug:
     msg: "hdfs_dependency_jars_dir: {{ hdfs_dependency_jars_dir }}"
@@ -81,13 +101,15 @@
 - name: check | verify dependency jars
   command: "ls /opt/hadoop/jars/{{ hdfs_dependency_jars_dir }}"
   register: dep_jars
-  when: ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
-
-- debug:
-    msg: "dep_jars: {{ dep_jars }}"
-
-- fail:
-    msg: "Dependency jars not exist in /opt/hadoop/jars directory."
   when:
     - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - transparency_322_enabled|bool == False
+
+- fail:
+    msg: >
+      "Dependency jars not exist in /opt/hadoop/jars directory, which are essential prerequisites, For further details, "
+      "please consult the documentation via the following link: https://www.ibm.com/docs/en/storage-scale-bda?topic=hdfs-setup"
+  when:
+    - ansible_fqdn in scale_hdfs_nodes_list or inventory_hostname in scale_hdfs_nodes_list
+    - transparency_322_enabled|bool == False
     - dep_jars.rc != 0


### PR DESCRIPTION
Implemented validation in the deploy pre-check to verify the existence of the /var/hadoop/jars folder. The deployment process proceeds (if hdfs is enabled) only if the folder exists; otherwise, the execution is terminated.