### PR TITLE
D324616: 'dict object' has no attribute 'stdout_lines'

### DIFF
--- a/roles/hdfs_prepare/tasks/java_home.yml
+++ b/roles/hdfs_prepare/tasks/java_home.yml
@@ -81,7 +81,7 @@
   ignore_errors: true
 
 - debug:
-    msg: "gpfs_hdfs_protocol_version: {{ gpfs_hdfs_protocol_version.stdout_lines[0] }}"
+    msg: "gpfs_hdfs_protocol_version: {{ gpfs_hdfs_protocol_version}}"
 
 - name: Check gpfs.hdfs-protocol version for standalone installation
   fail:


### PR DESCRIPTION
The wrong param value was added in the debug statement...fixed.

- debug:
    msg: "gpfs_hdfs_protocol_version: {{ gpfs_hdfs_protocol_version.}}"