### PR TITLE
Extending '--directory-object' flag for mmafmcosconfig

### DIFF
--- a/roles/afm_cos_configure/tasks/afm_configure.yml
+++ b/roles/afm_cos_configure/tasks/afm_configure.yml
@@ -51,7 +51,7 @@
                 (scale_afm_cos_config_params.is_gcs is defined and scale_afm_cos_config_params.is_gcs|bool)"
     
       - name: configure | Create a AFM cos relationship with filesets
-        command: "{{ scale_command_path }}mmafmcosconfig {{ item.filesystem }} {{ item.fileset }}  --endpoint {{ item.endpoint }}  {{ extra_option_flag }}"
+        command: "{{ scale_command_path }}mmafmcosconfig {{ item.filesystem }} {{ item.fileset }}  --endpoint {{ item.endpoint }}  {{ extra_option_flag }} --directory-object"
         register: scale_afm_cos_define
         failed_when: scale_afm_cos_define.rc != 0
         when:


### PR DESCRIPTION
Signed-off-by: Rajan Mishra <rajanmis@in.ibm.com>