### PR TITLE
Ansible deprecated and discontinued api fixes

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ibm
 name: spectrum_scale
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.0.0
+version: 3.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/core_common/tasks/check.yml
+++ b/roles/core_common/tasks/check.yml
@@ -88,15 +88,15 @@
 
 # set dynamic variable based on supported OS
 - name: check | Set variables based on yum/dnf based OS
-  include: yum/set_vars.yml
+  include_tasks: yum/set_vars.yml
   when: ansible_distribution in scale_rhel_distribution
 
 - name: check | Set variables based on apt based os
-  include: apt/set_vars.yml
+  include_tasks: apt/set_vars.yml
   when: ansible_distribution in scale_ubuntu_distribution
 
 - name: check | Set variables based on zypper based OS
-  include: zypper/set_vars.yml
+  include_tasks: zypper/set_vars.yml
   when: ansible_distribution in scale_sles_distribution
 
 - name: check | Storage Scale GPG key

--- a/roles/encryption_configure/tasks/add_gklm_keyserver.yml
+++ b/roles/encryption_configure/tasks/add_gklm_keyserver.yml
@@ -38,7 +38,7 @@
 
 - name: Encryption | Adding GKLM Server
   shell: |
-    echo -e "yes" | mmkeyserv server add "{{ scale_encryption_servers[0] }}" --backup {% if scale_encryption_servers|length > 1 %}"{{ scale_encryption_servers[1:] | join(',') }}"{% endif %} --server-pwd "{{ password_file }}"
+    mmkeyserv server add "{{ scale_encryption_servers[0] }}" --backup {% if scale_encryption_servers|length > 1 %}"{{ scale_encryption_servers[1:] | join(',') }}"{% endif %} --server-pwd "{{ password_file }}" --accept
   register: add_keyserver_output
   run_once: true
 

--- a/roles/encryption_prepare/tasks/copy_master_backup_clone.yml
+++ b/roles/encryption_prepare/tasks/copy_master_backup_clone.yml
@@ -1,6 +1,10 @@
 ---
 # Sharing the master backup across all clones
 
+- name: Define copy_status variable
+  set_fact:
+    copy_status: []
+
 - name: Encryption | Copy Master Backup
   fetch:
     src: "{{ gklm_backup_dir }}/{{ master_backup_jar_file }}"
@@ -8,26 +12,35 @@
     flat: yes
     fail_on_missing: yes
   delegate_to: "{{ scale_encryption_servers[0] }}"
+  run_once: true    
+
+- name: Determine if the host is not the first scale_encryption_server
+  set_fact:
+    is_not_first_server: "{{ inventory_hostname != scale_encryption_servers[0] }}"
   run_once: true
+  delegate_to: localhost
 
 - name: Encryption | Copy Master Backup to Clone
   copy:
     src: "/tmp/{{ master_backup_jar_file }}"
     dest: "{{ gklm_backup_dir }}/{{ master_backup_jar_file }}"
   delegate_to: "{{ item }}"
-  with_items: "{{ scale_encryption_servers }}"
-  when: inventory_hostname != scale_encryption_servers[0]
-  run_once: true
+  register: copy_result
+  loop: "{{ scale_encryption_servers }}"
+  when: "item != scale_encryption_servers[0]"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
 
 - name: Encryption | Change Backup file permission
   ansible.builtin.file:
     path: "{{ gklm_backup_dir }}/{{ master_backup_jar_file }}"
     owner: "{{ gklm_user }}"
+    mode: '0644'
   become: true
   delegate_to: "{{ item }}"
-  with_items: "{{ scale_encryption_servers }}"
-  when: inventory_hostname != scale_encryption_servers[0]
-  run_once: true
+  loop: "{{ scale_encryption_servers }}"
+  when: "item != scale_encryption_servers[0]"
 
 - debug:
-    var: copy_status
+    var: copy_result

--- a/roles/encryption_prepare/tasks/create_ssl_certificate.yml
+++ b/roles/encryption_prepare/tasks/create_ssl_certificate.yml
@@ -40,10 +40,11 @@
       country: "{{ ssl_cert_usage_country }}"
       validity: "{{ ssl_cert_validity }}"
       algorithm: "{{ ssl_cert_algorithm }}"
+    status_code: 201  # Accepting 201 as a successful response
     validate_certs: no
   register: certificate_creation
   run_once: true
-  ignore_errors: yes
+  ignore_errors: true
 
 - debug:
     var: certificate_creation.status

--- a/roles/hdfs_upgrade/handlers/mail.yml
+++ b/roles/hdfs_upgrade/handlers/mail.yml
@@ -2,5 +2,3 @@
  # handlers file for node
  - name: yum-clean-metadata
    command: yum clean metadata
-   args:
-     warn: false

--- a/roles/hdfs_verify/README.md
+++ b/roles/hdfs_verify/README.md
@@ -1,1 +1,80 @@
-../../docs/README.HDFS.md
+Role Definition
+-------------------------------
+- Role name: HDFS
+- Definition:
+  - HDFS is a network protocol used by Windows-based computers that allows systems within the same network to share files.
+  - It allows computers connected to the same network or domain to access files from other local computers as easily as if they 
+  were on the computer's local hard drive.
+
+OS/Arch Support:
+---------------------------
+- Arch : 
+   -1: x86
+   -2: PowerLe
+- OS   :
+   -1: RHEL7
+   -2: RHEL8
+
+Prerequisite
+----------------------------
+- CES should be enabled and configured.
+- Atleast 1 node should be designated as hdfs node.
+- Native hdfs service should be stopped, before usinf this role.
+- Atleast one dedicated cesip required for hdfs role.
+- Make sure, JAVA 1.8.0 version(java-<1.8.0>-openjdk-devel) should be installed on all the hdfs host nodes and JAVA_HOME exported.
+  -1:
+     # yum installjava-1.8.0-openjdk-devel
+  -2:
+     # vi ~/.bashrc
+     # export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+     # export PATH=$PATH:$JAVA_HOME/bin
+
+Design
+---------------------------
+- Directory Structure:
+  - Path: /ibm-spectrum-scale-install-infra/roles/scale_hdfs
+  - Inside the scale_hdfs role, there are four more roles to enable microservice architecture:
+    - `Precheck`: This role checks that all the prerequisites are satisfied before installing the hdfs rpms. It checks the following things:
+      - Whether hdfs protocol is enabled or not.
+      - Whether atleast one hdfs node is specified or not.
+      - Whether supporting JAVA installed on all the hdfs nodes.
+    - `Node`: This role installs the rpms required for hdfs protocol functionality. There are 3 methods to install hdfs rpms:  
+      - via local package, requires  scale_install_localpkg_path variable to be set in main playbook.
+      - via remote package, requires scale_install_remotepkg_path variable to be set in main playbook.
+      - via yum repository, requires scale_install_callhome_repository_url variable to be set in main playbook.
+    - `Cluster`: This role configure and enables the hdfs protocol.
+    - `Postcheck`: This role checks if hdfs service is running or not.
+
+Implementation
+-------------------------
+- `Precheck`
+  - This role creates a list of hdfs nodes and checks if atleast one node is set as hdfs nodes.
+  - It checks if all prerequisites are satisfied like supported JAVA installed and JAVA_HOME set(currently java-1.8.0-openjdk supported)
+  
+- `Node`
+  - Installation via local package: rpms are on local machine
+    - File name: install_local_pkg.yml
+    - Path: /root/ibm-spectrum-scale-install-infra/roles/scale_hdfs/node/tasks
+    - This playbook checks whether the package exists, checks for valid checksum, extracts all the rpms and creates a list 
+    ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install hdfs.
+  - Installation via remote package: rpms are on remote machine
+    - File name: install_remote_pkg.yml
+    - Path: /root/ibm-spectrum-scale-install-infra/roles/scale_hdfs/node/tasks
+    - This playbook checks whether the package exists, checks for valid checksum, extracts all the rpms and creates a list ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install hdfs.
+  - Installation via repository: rpms are in yum repo
+    - File name: install_repository.yml
+    - Path: /root/ibm-spectrum-scale-install-infra/roles/scale_hdfs/node/tasks
+    - This playbook configures the yum repo using the URL mentioned in variable scale_install_hdfs_repository_url and creates a list ‘scale_install_all_rpms’ that contains all the rpms and dependencies required to install hdfs.
+  - The installation method is selected in the playbook ‘install.yml’ . Installation method depends on the variables defined.
+    - If  ‘scale_install_hdfs_repository_url’ is defined, then the installation method is repository.
+    -	If  ‘scale_install_repository_url’ is undefined and ‘scale_install_remotepkg_path’ is defined, then the installation method is remote.
+    -	If  ‘scale_install_repository_url’ is undefined and ‘scale_install_remotepkg_path’ is undefined and ‘scale_install_localpkg_path’ is defined, then the installation method is local.
+  - Depending on the installation method, appropriate playbook is called for collecting the rpms and rpms are installed on all the nodes on which hdfs is enabled. 
+
+- `Cluster`
+  - This role setup all hdfs required configurations.
+  - To enable hdfs protocol, we run command `mmces service enable hdfs` on all the nodes where hdfs is enabled.
+
+- `Postcheck`
+  - This role verify namenodes and datanodes status.
+  - This role uses command `mmces service list` to check if hdfs service is up and running.

--- a/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
+++ b/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
@@ -261,7 +261,6 @@
     - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Remove json spesific information to a plain pub key file.
       shell:
         cmd: sed 's/,/\n/g' {{ scale_remotemount_storage_pub_key_location_json }} | tr -d '"\[\]' | sed 's/^ //' > {{ scale_remotemount_storage_pub_key_location }}
-        warn: false
       run_once: true
 
     - name: Step 3 - Remote Cluster Config - API-CLI
@@ -293,9 +292,17 @@
       run_once: True
 
     - set_fact:
-        owning_nodes_name: "{{ owning_nodes_name }} + [ '{{ item.adminNodeName }}' ]"
-      with_items: "{{ owning_cluster_nodes.json.nodes }}"
+        owning_nodes_name: "{{ owning_cluster_nodes.json.nodes | map(attribute='adminNodeName') | list }}"
       run_once: True
+
+    - name: Debug owning_nodes_name
+      debug:
+        var: owning_nodes_name
+
+    - name: Debug each item
+      debug:
+        var: item
+      loop: "{{ owning_nodes_name }}"
 
 #
 # This Section is when using daemonNodeName
@@ -304,7 +311,7 @@
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{item}}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{ item }}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -319,12 +326,18 @@
         owning_daemon_nodes_name: []
       run_once: True
 
+        #- set_fact:
+        #owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
+        #with_items: "{{ owning_cluster_daemonnodes.results }}"
+        #run_once: True
 
     - set_fact:
-        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
-      with_items: "{{ owning_cluster_daemonnodes.results }}"
+        owning_daemon_nodes_name: "{{ owning_cluster_daemonnodes.results | map(attribute='json.nodes.0.network.daemonNodeName') | list }}"
       run_once: True
 
+    - name: Print out the array storing the DeamonNodeNames from the Storage Cluster (owning)
+      debug:
+        var: owning_daemon_nodes_name
 
 #
 # adminNodeName section


### PR DESCRIPTION
Signed-off-by: hvkrishn@us.ibm.com

1. [re-writing the looping logic](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/9dbb7428f09d155e6430ccf445270e06dcec40bf)
2. [Replacing symlink with the actual file to get past ansible collection build errors](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/aef5d689c31b9d3fc4a67a4ff318dcb6433f0bfa)
3. [command args/warn: false has been discontinued and is now the default state](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/a66da6e9e79c28fdfd58fa05e60e75eb818626be)
4. [expecting response_status 201 for Cert creation instead of 200](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/aa4605e5337a6d124fa6d8ff70d7b445e998954f)
5. [Re-writing the looping logic](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/942522d88883f8ad4389ead81350646c7291cfe9)
6. [using mmkeyserv --access instead of piping 'yes' to accept](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/3e47a979674aa5f918b4a9dc0e23fd583c1a6676)
7. [replacing 'include; with 'include_tasks'](https://github.com/c0mpiler/ibm-spectrum-scale-install-infra/commit/2c4154b13be3942db3918a7998cada87880bb798)