### PR TITLE
Adding OpenLDAP SSSD support

### DIFF
--- a/roles/auth_configure/tasks/ldap_prerequisites.yml
+++ b/roles/auth_configure/tasks/ldap_prerequisites.yml
@@ -1,34 +1,21 @@
 ---
 # Installing required ldap client packages for the integration.
 
-- name: LDAP | Installing Packages
+- name: LDAP | Check OS version for OpenLDAP package installation
   ansible.builtin.shell: "grep -oE 'release [0-9]+' /etc/redhat-release | awk '{print $2}'"
   register: rhel_version
   changed_when: false
 
-- name: LDAP | Install Packages for RHEL 7
-  ansible.builtin.yum:
-    name:
-      - openldap-clients
-      - nss-pam-ldapd
-      - sssd
-      - oddjob
-      - oddjob-mkhomedir
-    state: present
-  when: rhel_version.stdout == "7"
-  register: install_ldap_client
-
-- name: LDAP | Install Packages for RHEL 8
+- name: LDAP | Install Required OpenLDAP Packages
   ansible.builtin.dnf:
     name:
       - libnsl
       - libnsl2
       - openldap-clients
-      - nss-pam-ldapd
-      - authselect
       - sssd
-      - oddjob
+      - sssd-ldap
       - oddjob-mkhomedir
+      - openssl-perl
+      - authselect
     state: present
-  when: rhel_version.stdout == "8"
-  register: install_ldap_client
+  when: rhel_version.stdout in ["8", "9"]

--- a/roles/auth_configure/tasks/ldap_user_integration.yml
+++ b/roles/auth_configure/tasks/ldap_user_integration.yml
@@ -1,79 +1,69 @@
 ---
-# Installing required LDAP client packages for the integration.
 
-- name: LDAP | OS version check
+- name: LDAP | Check OS version
   ansible.builtin.shell: "grep -oE 'release [0-9]+' /etc/redhat-release | awk '{print $2}'"
   register: rhel_version
   changed_when: false
 
 - block:
-    - name: LDAP | Enable LDAP authentication
+    - name: LDAP | Check for existing ldap_cacert.pem
+      ansible.builtin.stat:
+        path: "{{ LDAP_CERT_FILES_DIR }}/ldap_cacert.pem"
+      register: ldap_cert_stat
+
+    - name: LDAP | Copy ldap_cacert.pem to remote servers if not present
+      ansible.builtin.copy:
+        src: "{{ LDAP_CERT_FILES_DIR }}/ldap_cacert.pem"
+        dest: /etc/openldap/certs/ldap_cacert.pem
+        owner: root
+        group: root
+        mode: '0600'
+      when: not ldap_cert_stat.stat.exists
+      register: ldap_cert_result
+
+    - name: LDAP | Update LDAP configuration with server details
+      ansible.builtin.blockinfile:
+        path: /etc/openldap/ldap.conf
+        block: |
+          BASE   dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }}
+          URI    ldap://{{ LDAP_SERVER_IP }}/
+          TLS_CACERT /etc/openldap/certs/ldap_cacert.pem
+          TLS_CACERTDIR /etc/openldap/certs
+        create: yes
+
+    - name: LDAP | Rehash certificates in OpenLDAP directory
       ansible.builtin.command:
-        cmd: authconfig --enableldap --enableldapauth --ldapserver=ldap://{{ LDAP_SERVER_IP }} --ldapbasedn="dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }}" --enablemkhomedir --update
-      register: enable_authconfig
+        cmd: openssl rehash /etc/openldap/certs
 
-    - debug:
-        var: enable_authconfig.stdout_lines
+    - name: LDAP | Configure SSSD with mkhomedir
+      ansible.builtin.command:
+        cmd: authselect select sssd with-mkhomedir --force
 
-    - name: Update nsswitch.conf
-      ansible.builtin.lineinfile:
-        path: /etc/nsswitch.conf
-        regexp: "{{ item.regexp }}"
-        line: "{{ item.line }}"
-      loop:
-        - { regexp: '^passwd:', line: 'passwd: files ldap' }
-        - { regexp: '^shadow:', line: 'shadow: files ldap' }
-        - { regexp: '^group:', line: 'group: files ldap' }
-
-    - name: Remove 'auth' lines from password-auth PAM configuration
-      ansible.builtin.lineinfile:
-        path: "{{ item }}"
-        state: absent
-        regexp: '^auth.*'
-      loop:
-        - /etc/pam.d/password-auth
-        - /etc/pam.d/system-auth
-
-    - name: Add custom auth lines to PAM configuration files
-      ansible.builtin.blockinfile:
-        path: "{{ item }}"
-        block: |
-          auth        required      pam_env.so
-          auth        sufficient    pam_unix.so nullok try_first_pass
-          auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
-          auth        sufficient    pam_ldap.so use_first_pass
-          auth        required      pam_deny.so
-        create: yes
-      loop:
-        - /etc/pam.d/password-auth
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/sshd
-
-    - name: Remove nslcd.conf file
+    - name: LDAP | Remove existing SSSD configuration file if present
       ansible.builtin.file:
-        path: /etc/nslcd.conf
+        path: /etc/sssd/sssd.conf
         state: absent
 
-    - name: LDAP | Update LDAP Configuration with LDAP_SERVER and BASE_DN
-      ansible.builtin.blockinfile:
-        path: /etc/nslcd.conf
-        block: |
-          uid nslcd
-          gid ldap
-          uri ldap://{{ LDAP_SERVER_IP }}/
-          base dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }}
-        create: yes
+    - name: LDAP | Create new SSSD configuration file
+      ansible.builtin.template:
+        src: sssd.conf.j2
+        dest: /etc/sssd/sssd.conf
+        mode: '0600'
+        owner: root
+        group: root
 
-    - name: Allow SSH authentication
-      ansible.builtin.command: sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
-      notify: Restart SSH Service
-
-    - name: Restart and enable the services
+    - name: LDAP | Restart and enable SSSD and oddjobd services
       ansible.builtin.systemd:
         name: "{{ item }}"
         state: restarted
         enabled: yes
       loop:
-        - nslcd
-        - nscd
-  when: rhel_version.stdout in ["7", "8"]
+        - sssd
+        - oddjobd
+
+    - name: LDAP | Allow SSH password authentication
+      ansible.builtin.command:
+        cmd: sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+      notify: Restart SSH Service
+
+  when: rhel_version.stdout in ["8", "9"]

--- a/roles/auth_configure/tasks/user_auth_ldap.yml
+++ b/roles/auth_configure/tasks/user_auth_ldap.yml
@@ -1,13 +1,45 @@
 ---
 # Authenticating LDAP to the cluster
 
-- name: LDAP | Authenticate Cluster
-  shell: |
-    echo -e "{{ ldap_admin_password }}" | mmuserauth service create --type ldap --data-access-method file --servers {{ ldap_server }} --base-dn dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }} --user-name cn=admin,dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }} --netbios-name ces
-  when: service_result.rc is defined and service_result.rc != 0
-  register: ldap_authenticate_cluster
-  ignore_errors: yes
+- name: LDAP | CES - Check if LDAP authentication is already configured
+  shell: mmuserauth service list
+  register: ldap_config_check
+  changed_when: false
   run_once: true
 
-- debug:
-    var: ldap_authenticate_cluster.stdout_lines
+- name: LDAP | CES - Authenticate Cluster with LDAP
+  shell: |
+    echo -e "{{ ldap_admin_password }}" | mmuserauth service create \
+      --type ldap \
+      --data-access-method file \
+      --servers {{ ldap_server }} \
+      --base-dn "dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }}" \
+      --user-name "cn=admin,dc={{ BASE_DN.split('.')[0] }},dc={{ BASE_DN.split('.')[1] }}" \
+      --netbios-name ces
+  when: "'LDAP' not in ldap_config_check.stdout"
+  register: ldap_authenticate_cluster
+  run_once: true
+
+# Following tasks have been added to prevent updates to the sssd.conf file after "CES - Authenticate Cluster with LDAP."
+- name: LDAP | CES - Ensure SSSD Configuration File is Absent
+  ansible.builtin.file:
+    path: /etc/sssd/sssd.conf
+    state: absent
+    force: yes
+  when: ldap_authenticate_cluster.changed
+
+- name: LDAP | CES - Deploy SSSD Configuration File
+  ansible.builtin.template:
+    src: sssd.conf.j2
+    dest: /etc/sssd/sssd.conf
+    mode: '0600'
+    owner: root
+    group: root
+  when: ldap_authenticate_cluster.changed
+
+- name: LDAP | CES - Restart SSSD Service
+  ansible.builtin.systemd:
+    name: sssd
+    state: restarted
+    enabled: yes
+  when: ldap_authenticate_cluster.changed

--- a/roles/auth_configure/templates/sssd.conf.j2
+++ b/roles/auth_configure/templates/sssd.conf.j2
@@ -1,0 +1,21 @@
+[sssd]
+config_file_version = 2
+services = nss, pam, autofs
+domains = default
+
+[nss]
+homedir_substring = /home
+
+[pam]
+
+[domain/default]
+id_provider = ldap
+autofs_provider = ldap
+auth_provider = ldap
+chpass_provider = ldap
+ldap_uri = ldap://{{ LDAP_SERVER_IP }}
+ldap_search_base = dc={{ BASE_DN | regex_replace('\\..*', '') }},dc={{ BASE_DN | regex_replace('^[^.]+\\.', '') }}
+ldap_id_use_start_tls = True
+ldap_tls_cacertdir = /etc/openldap/certs
+cache_credentials = True
+ldap_tls_reqcert = allow

--- a/roles/auth_configure/vars/main.yml
+++ b/roles/auth_configure/vars/main.yml
@@ -1,3 +1,4 @@
 LDAP_ADMIN_PASSWORD: "{{ ldap_admin_password }}"
 BASE_DN: "{{ ldap_basedns }}"
 LDAP_SERVER_IP: "{{ ldap_server }}"
+LDAP_CERT_FILES_DIR: "/opt/IBM/ibm-spectrumscale-cloud-deploy/ldap_key"

--- a/roles/auth_ldap_server_prepare/tasks/get_ldap_certs.yml
+++ b/roles/auth_ldap_server_prepare/tasks/get_ldap_certs.yml
@@ -1,0 +1,19 @@
+---
+# Getting OpenLDAP SSL cert
+
+- name: LDAP | Check if ldap_cacert.pem exists on remote
+  stat:
+    path: /usr/local/share/ca-certificates/ldap_cacert.pem
+  register: remote_cert_status
+
+- name: LDAP | Check if ldap_cacert.pem exists locally
+  stat:
+    path: "{{ LDAP_CERT_FILES_DIR }}/ldap_cacert.pem"
+  register: ldap_cert_status
+
+- name: LDAP | Copy ldap_cacert.pem to Bootstrap
+  fetch:
+    src: /usr/local/share/ca-certificates/ldap_cacert.pem
+    dest: "{{ LDAP_CERT_FILES_DIR }}/ldap_cacert.pem"
+    flat: yes
+  when: remote_cert_status.stat.exists and not ldap_cert_status.stat.exists

--- a/roles/auth_ldap_server_prepare/tasks/ldap_env.yml
+++ b/roles/auth_ldap_server_prepare/tasks/ldap_env.yml
@@ -1,10 +1,203 @@
 ---
-# Creating LDAP directory to store the LDIF files.
+    - name: LDAP | LDAP Directory | Creation 
+      file:
+        path: "{{ LDAP_DIR }}"
+        state: directory
+      register: create_dir_output
+      run_once: true
 
-- name: LDAP | LDAP Directory | Creation 
-  file:
-    path: "{{ LDAP_DIR }}"
-    state: directory
-  register: create_dir_output
-  run_once: true
+    - name: LDAP | Update apt package index
+      apt:
+        update_cache: yes
 
+    - name: LDAP | Set basedomain and rootdomain
+      set_fact:
+        basedomain: "{{ BASE_DN.split('.')[0] }}"
+        rootdomain: "{{ BASE_DN.split('.')[1] }}"
+
+    - name: LDAP | Debug basedomain and rootdomain values
+      debug:
+        msg:
+          - "Basedomain: {{ basedomain }}"
+          - "Rootdomain: {{ rootdomain }}"
+
+    - name: LDAP | Install required packages
+      apt:
+        name:
+          - nfs-common
+          - gnutls-bin
+          - ssl-cert
+          - debconf-utils
+        state: present
+        force_apt_get: yes
+
+    - name: LDAP | Install the openldap and required packages for ubuntu
+      ansible.builtin.apt:
+        name: "{{ OPENLDAP_SERVER_PKGS }}"
+        state: present
+        update_cache: true
+      when: ansible_os_family == 'Debian'
+
+    - name: LDAP | Reconfigure slapd
+      shell: |
+        echo "slapd slapd/root_password password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/root_password_again password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/internal/adminpw password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/internal/generated_adminpw password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/password1 password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/password2 password {{ LDAP_ADMIN_PASSWORD }}" | debconf-set-selections
+        echo "slapd slapd/domain string {{ BASE_DN }}" | debconf-set-selections
+        echo "slapd shared/organization string {{ LDAP_GROUP }}" | debconf-set-selections
+        echo "slapd slapd/purge_database boolean false" | debconf-set-selections
+        echo "slapd slapd/move_old_database boolean true" | debconf-set-selections
+        echo "slapd slapd/no_configuration boolean false" | debconf-set-selections
+        dpkg-reconfigure -f noninteractive slapd
+
+    - name: LDAP | Set BASE in ldap.conf
+      lineinfile:
+        path: /etc/ldap/ldap.conf
+        line: "BASE   dc={{ basedomain }},dc={{ rootdomain }}"
+        create: yes
+
+    - name: LDAP | Set URI in ldap.conf
+      lineinfile:
+        path: /etc/ldap/ldap.conf
+        line: "URI    ldap://localhost"
+        create: yes
+
+    - name: LDAP | Restart slapd service
+      service:
+        name: slapd
+        state: restarted
+
+    - name: LDAP | Check slapd service status
+      command: systemctl status slapd
+      register: slapd_status
+
+    - name: LDAP | Display slapd status
+      debug:
+        var: slapd_status
+
+    - name: LDAP | Generate private key for CA
+      command:
+        cmd: >
+          certtool --generate-privkey --sec-param High --outfile /etc/ssl/private/ldap_cakey.pem
+      args:
+        creates: /etc/ssl/private/ldap_cakey.pem
+
+    - name: LDAP | Create CA template file
+      copy:
+        dest: /etc/ssl/ca.info
+        content: |
+          cn = {{ LDAP_GROUP }}
+          ca
+          cert_signing_key
+          expiration_days = 3650
+
+    - name: LDAP | Generate self-signed CA certificate
+      command:
+        cmd: >
+          certtool --generate-self-signed
+          --load-privkey /etc/ssl/private/ldap_cakey.pem
+          --template /etc/ssl/ca.info
+          --outfile /usr/local/share/ca-certificates/ldap_cacert.pem
+      args:
+        creates: /usr/local/share/ca-certificates/ldap_cacert.pem
+
+    - name: LDAP | Update CA certificates
+      command: update-ca-certificates
+
+    - name: LDAP | Copy CA certificate to /etc/ssl/certs
+      copy:
+        src: /usr/local/share/ca-certificates/ldap_cacert.pem
+        dest: /etc/ssl/certs/ldap_cacert.pem
+        remote_src: yes
+
+    - name: LDAP | Generate private key for LDAP server
+      command:
+        cmd: >
+          certtool --generate-privkey --sec-param High --outfile /etc/ssl/private/ldapserver_slapd_key.pem
+      args:
+        creates: /etc/ssl/private/ldapserver_slapd_key.pem
+
+    - name: LDAP | Create LDAP server certificate template
+      copy:
+        dest: /etc/ssl/ldapserver.info
+        content: |
+          organization = {{ LDAP_GROUP }}
+          cn = localhost
+          tls_www_server
+          encryption_key
+          signing_key
+          expiration_days = 3650
+
+    - name: LDAP | Generate certificate for LDAP server signed by CA
+      command:
+        cmd: >
+          certtool --generate-certificate
+          --load-privkey /etc/ssl/private/ldapserver_slapd_key.pem
+          --load-ca-certificate /etc/ssl/certs/ldap_cacert.pem
+          --load-ca-privkey /etc/ssl/private/ldap_cakey.pem
+          --template /etc/ssl/ldapserver.info
+          --outfile /etc/ssl/certs/ldapserver_slapd_cert.pem
+      args:
+        creates: /etc/ssl/certs/ldapserver_slapd_cert.pem
+
+    - name: LDAP | Set proper permissions for LDAP server private key
+      file:
+        path: /etc/ssl/private/ldapserver_slapd_key.pem
+        group: openldap
+        mode: "0640"
+        state: file
+
+    - name: LDAP | Add openldap to ssl-cert group
+      command: gpasswd -a openldap ssl-cert
+
+    - name: LDAP | Pause for 2 seconds
+      command: sleep 2
+
+    - name: LDAP | Restart slapd service
+      service:
+        name: slapd
+        state: restarted
+
+    - name: LDAP | Create LDIF file for TLS configuration
+      copy:
+        dest: /etc/ssl/certinfo.ldif
+        content: |
+          dn: cn=config
+          add: olcTLSCACertificateFile
+          olcTLSCACertificateFile: /etc/ssl/certs/ldap_cacert.pem
+          -
+          add: olcTLSCertificateFile
+          olcTLSCertificateFile: /etc/ssl/certs/ldapserver_slapd_cert.pem
+          -
+          add: olcTLSCertificateKeyFile
+          olcTLSCertificateKeyFile: /etc/ssl/private/ldapserver_slapd_key.pem
+
+    - name: LDAP | Apply TLS configuration using ldapmodify
+      command:
+        cmd: ldapmodify -Y EXTERNAL -H ldapi:/// -f /etc/ssl/certinfo.ldif
+
+    - name: LDAP | Pause for 2 seconds
+      command: sleep 2
+
+    - name: LDAP | Update slapd to listen on ldaps://
+      replace:
+        path: /etc/default/slapd
+        regexp: 'SLAPD_SERVICES="ldap:/// ldapi:///"'
+        replace: 'SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"'
+
+    - name: LDAP | Update ldap.conf with TLS configuration
+      copy:
+        dest: /etc/ldap/ldap.conf
+        content: |
+          BASE    dc={{ basedomain }},dc={{ rootdomain }}
+          URI    ldap://localhost
+          TLS_CACERT /etc/ssl/certs/ldap_cacert.pem
+          TLS_REQCERT allow
+
+    - name: LDAP | Restart slapd service after configuration
+      service:
+        name: slapd
+        state: restarted

--- a/roles/auth_ldap_server_prepare/tasks/ldap_installation_status.yml
+++ b/roles/auth_ldap_server_prepare/tasks/ldap_installation_status.yml
@@ -1,0 +1,10 @@
+---
+- name: LDAP | Check if LDAP configuration is already applied
+  stat:
+    path: /etc/ldap/.ldap_configured
+  register: ldap_config_status
+
+- name: LDAP | Skip configuration if already applied
+  debug:
+    msg: "LDAP configuration already applied, skipping."
+  when: ldap_config_status.stat.exists

--- a/roles/auth_ldap_server_prepare/tasks/ldap_users.yml
+++ b/roles/auth_ldap_server_prepare/tasks/ldap_users.yml
@@ -41,3 +41,8 @@
   debug:
     msg: "LDAP User '{{ LDAP_USER }}' already exists. Skipping."
   when: ldap_user_search.stdout == "UserFound"
+
+- name: LDAP | Mark LDAP configuration as completed
+  file:
+    path: /etc/ldap/.ldap_configured
+    state: touch

--- a/roles/auth_ldap_server_prepare/tasks/main.yml
+++ b/roles/auth_ldap_server_prepare/tasks/main.yml
@@ -3,17 +3,26 @@
 # Integration LDAP with IBM Spectrum Scale (GPFS) for user level access.
 # Below are the LDAP Server configuration tasks to add OU, Groups and Users.
 
-# Import the 'ldap_env.yml' task for setting the env to store the LDAP configuration files.
-- import_tasks: ldap_env.yml
+# Check if LDAP configuration is already applied
+- import_tasks: ldap_installation_status.yml
 
-# Import the 'ldap_users.yml' task for adding OU to LDAP.
-- import_tasks: ldap_base_ou.yml
+# Conditionally execute tasks if LDAP is not configured
+- block:
+    # Import the 'ldap_env.yml' task for setting the env to store the LDAP configuration files.
+    - import_tasks: ldap_env.yml
 
-# Import the 'ldap_groups.yml' task for adding groups to LDAP.
-- import_tasks: ldap_groups.yml
+    # Import the 'get_ldap_certs.yml' task for getting the SSL certificate.
+    - import_tasks: get_ldap_certs.yml
 
-# Import the 'ldap_users.yml' task for adding users to LDAP.
-- import_tasks: ldap_users.yml
+    # Import the 'ldap_base_ou.yml' task for adding OU to LDAP.
+    - import_tasks: ldap_base_ou.yml
 
-# Import the 'cleanup_secrets.yml' task for cleaning the confidential files stored locally.
-- import_tasks: cleanup_secrets.yml
+    # Import the 'ldap_groups.yml' task for adding groups to LDAP.
+    - import_tasks: ldap_groups.yml
+
+    # Import the 'ldap_users.yml' task for adding users to LDAP.
+    - import_tasks: ldap_users.yml
+
+    # Import the 'cleanup_secrets.yml' task for cleaning the confidential files stored locally.
+    - import_tasks: cleanup_secrets.yml
+  when: not ldap_config_status.stat.exists

--- a/roles/auth_ldap_server_prepare/vars/main.yml
+++ b/roles/auth_ldap_server_prepare/vars/main.yml
@@ -5,3 +5,7 @@ LDAP_USER: "{{ ldap_user_name }}"
 LDAP_USER_PASSWORD: "{{ ldap_user_password }}"
 BASE_DN: "{{ ldap_basedns }}"
 LDAP_SERVER_IP: "{{ ldap_server }}"
+LDAP_CERT_FILES_DIR: "/opt/IBM/ibm-spectrumscale-cloud-deploy/ldap_key"
+OPENLDAP_SERVER_PKGS:
+  - slapd
+  - ldap-utils


### PR DESCRIPTION
- We are converting OpenLDAP Installation and configuration from Shell script user-data to Ansible playbook.

- Also we are transitioning OpenLDAP support from nslcd to sssd to ensure a consistent authentication setup across different environments.