### PR TITLE
Fixing OpenLDAP configuration issue with Storage Scale cluster

### DIFF
--- a/roles/auth_configure/tasks/ldap_prerequisites.yml
+++ b/roles/auth_configure/tasks/ldap_prerequisites.yml
@@ -1,21 +1,36 @@
 ---
-# Installing required ldap client packages for the integration.
-
-- name: LDAP | Check OS version for OpenLDAP package installation
-  ansible.builtin.shell: "grep -oE 'release [0-9]+' /etc/redhat-release | awk '{print $2}'"
-  register: rhel_version
-  changed_when: false
-
-- name: LDAP | Install Required OpenLDAP Packages
-  ansible.builtin.dnf:
-    name:
-      - libnsl
-      - libnsl2
-      - openldap-clients
-      - sssd
-      - sssd-ldap
-      - oddjob-mkhomedir
-      - openssl-perl
-      - authselect
-    state: present
-  when: rhel_version.stdout in ["8", "9"]
+    # Installing required LDAP client packages for integration.
+    
+    - name: LDAP | Check OS version for OpenLDAP package installation
+      ansible.builtin.shell: "grep -oE 'release [0-9]+' /etc/redhat-release | awk '{print $2}'"
+      register: rhel_version
+      changed_when: false
+    
+    - block:
+        - name: LDAP | Remove conflicting SSSD packages
+          ansible.builtin.package:
+            name:
+              - sssd-tools
+              - python3-sssdconfig
+            state: absent
+    
+        - name: LDAP | Install required OpenLDAP packages
+          ansible.builtin.dnf:
+            name:
+              - libnsl
+              - libnsl2
+              - openldap-clients
+              - sssd
+              - sssd-ldap
+              - oddjob-mkhomedir
+              - openssl-perl
+              - authselect
+            state: present
+    
+        - name: LDAP | Install conflicting SSSD packages separately
+          ansible.builtin.package:
+            name:
+              - sssd-tools
+              - python3-sssdconfig
+            state: present
+      when: rhel_version.stdout in ['8', '9']


### PR DESCRIPTION
**Problem Statement:** 

There is a production issue with Scale cluster creation when using OpenLDAP configuration. The process is failing due to a version dependency conflict between sssd-tools and python3-sssdconfig.

```
Depsolve Error occurred:
	
Problem: problem with installed package sssd-tools-2.9.4-4.el8_10.x86_64
  - package sssd-tools-2.9.4-4.el8_10.x86_64 from @System requires python3-sssdconfig = 2.9.4-4.el8_10, but none of the providers can be installed
  - package sssd-tools-2.9.4-4.el8_10.x86_64 from rhel-8-for-x86_64-baseos-rpms requires python3-sssdconfig = 2.9.4-4.el8_10, but none of the providers can be installed
  - cannot install both python3-sssdconfig-2.9.4-5.el8_10.1.noarch from rhel-8-for-x86_64-baseos-rpms and python3-sssdconfig-2.9.4-4.el8_10.noarch from @System
  - cannot install both python3-sssdconfig-2.9.4-5.el8_10.1.noarch from rhel-8-for-x86_64-baseos-rpms and python3-sssdconfig-2.9.4-4.el8_10.noarch from rhel-8-for-x86_64-baseos-rpms
  - package sssd-2.9.4-5.el8_10.1.x86_64 from rhel-8-for-x86_64-baseos-rpms requires python3-sssdconfig = 2.9.4-5.el8_10.1, but none of the providers can be installed
  - cannot install the best candidate for the job", "rc": 1, "results": []}
```

**Solution recommended:**

The below option worked well, and the deployment was successful. Most recommendations suggest removing and reinstalling the packages after installing the prerequisite packages.

Also, I tried "nobest" , "allowerasing" options. But, no use.
