### PR TITLE
Fix templating logic for multiple remotemount storage nodes

### DIFF
--- a/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
+++ b/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
@@ -288,12 +288,7 @@
       run_once: True
 
     - set_fact:
-        owning_nodes_name: []
-      run_once: True
-
-    - set_fact:
-        owning_nodes_name: "{{ owning_nodes_name }} + [ '{{ item.adminNodeName }}' ]"
-      with_items: "{{ owning_cluster_nodes.json.nodes }}"
+        owning_nodes_name: "{{ owning_cluster_nodes.json.nodes | map(attribute='adminNodeName') | list }}"
       run_once: True
 
 #
@@ -315,13 +310,7 @@
       run_once: True
 
     - set_fact:
-        owning_daemon_nodes_name: []
-      run_once: True
-
-
-    - set_fact:
-        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
-      with_items: "{{ owning_cluster_daemonnodes.results }}"
+        owning_daemon_nodes_name: "{{ owning_cluster_daemonnodes.results | map(attribute='json.nodes.0.network.daemonNodeName') | list }}"
       run_once: True
 
 


### PR DESCRIPTION
Without this, at least on ansible-core 2.16.14 and without jinja2_native set, this incorrectly just appends to a string for owning_nodes_name resulting in a URL for the task at roles/remotemount_configure/tasks/remotecluster_api_cli.yml:302 resulting in a URL like:

```
"url": "https://<ip>:443/scalemgmt/v2/nodes/[] + [ 'node0-data' ] + [ 'node1-data' ] + <snip> + [ 'node5-data' ]",
```