### PR TITLE
Supporting Routing table for RHEL9

### DIFF
--- a/roles/mrot_config/tasks/mrot_config.yaml
+++ b/roles/mrot_config/tasks/mrot_config.yaml
@@ -2,8 +2,20 @@
 
 # Task to check and add custom routing tables on cluster nodes.
 
+- name: Check for /etc/iproute2/rt_tables
+  stat:
+    path: /etc/iproute2/rt_tables
+  register: etc_rt_tables
+
+- name: Set rt_tables path
+  set_fact:
+    rt_tables_path: >-
+      {{ '/etc/iproute2/rt_tables'
+         if etc_rt_tables.stat.exists
+         else '/usr/share/iproute2/rt_tables' }}
+
 - name: check | Check if custom routing tables exist
-  shell: grep -q 'subnet_{{ item.network_addr_1 }}_{{ scale_pri_interface_name }}' /etc/iproute2/rt_tables && grep -q 'subnet_{{ item.network_addr_2 }}_{{ scale_sec_interface_name }}' /etc/iproute2/rt_tables
+  shell: grep -q 'subnet_{{ item.network_addr_1 }}_{{ scale_pri_interface_name }}' {{ rt_tables_path }} && grep -q 'subnet_{{ item.network_addr_2 }}_{{ scale_sec_interface_name }}' {{ rt_tables_path }}
   register: routing_table_exists
   ignore_errors: yes
   with_items: "{{ variable_sets }}"
@@ -14,8 +26,8 @@
 
 - name: configure | Custom routing tables
   shell: |
-    echo "200 subnet_{{ item.network_addr_1 }}_{{ scale_pri_interface_name }}" >> /etc/iproute2/rt_tables
-    echo "201 subnet_{{ item.network_addr_2 }}_{{ scale_sec_interface_name }}" >> /etc/iproute2/rt_tables
+    echo "200 subnet_{{ item.network_addr_1 }}_{{ scale_pri_interface_name }}" >> {{ rt_tables_path }}
+    echo "201 subnet_{{ item.network_addr_2 }}_{{ scale_sec_interface_name }}" >> {{ rt_tables_path }}
   with_items: "{{ variable_sets }}"
   when: routing_table_exists.results[0].rc != 0
 

--- a/roles/nfs_route_configure/tasks/nfs_route_configure.yml
+++ b/roles/nfs_route_configure/tasks/nfs_route_configure.yml
@@ -85,8 +85,20 @@
 
 # Task to check and add custom routing tables on cluster nodes.
 
+- name: Check for /etc/iproute2/rt_tables
+  stat:
+    path: /etc/iproute2/rt_tables
+  register: etc_rt_tables
+
+- name: Set rt_tables path
+  set_fact:
+    rt_tables_path: >-
+      {{ '/etc/iproute2/rt_tables'
+         if etc_rt_tables.stat.exists
+         else '/usr/share/iproute2/rt_tables' }}
+
 - name: check | Check if custom routing tables exist
-  shell: grep -q 'subnet_{{ storage_network_addr.stdout_lines[0] }}_{{ scale_pri_interface_name }}' /etc/iproute2/rt_tables && grep -q 'subnet_{{ protocol_network_addr.stdout_lines[0] }}_{{ scale_sec_interface_name }}' /etc/iproute2/rt_tables
+  shell: grep -q 'subnet_{{ storage_network_addr.stdout_lines[0] }}_{{ scale_pri_interface_name }}' {{ rt_tables_path }} && grep -q 'subnet_{{ protocol_network_addr.stdout_lines[0] }}_{{ scale_sec_interface_name }}' {{ rt_tables_path }}
   register: routing_table_exists
   when: scale_protocol_node | default(false) == true
   ignore_errors: yes
@@ -98,8 +110,8 @@
 
 - name: configure | Custom routing tables
   shell: |
-    echo "200 subnet_{{ storage_network_addr.stdout_lines[0] }}_{{ scale_pri_interface_name }}" >> /etc/iproute2/rt_tables
-    echo "201 subnet_{{ protocol_network_addr.stdout_lines[0] }}_{{ scale_sec_interface_name }}" >> /etc/iproute2/rt_tables
+    echo "200 subnet_{{ storage_network_addr.stdout_lines[0] }}_{{ scale_pri_interface_name }}" >> {{ rt_tables_path }}
+    echo "201 subnet_{{ protocol_network_addr.stdout_lines[0] }}_{{ scale_sec_interface_name }}" >> {{ rt_tables_path }}
   when: scale_protocol_node | default(false) == true and routing_table_exists.rc != 0
 
 # Task to check and add custom IP rules on cluster nodes.

--- a/roles/remotemount_configure/tasks/remotecluster.yml
+++ b/roles/remotemount_configure/tasks/remotecluster.yml
@@ -285,10 +285,10 @@
       run_once: True
 
     - set_fact:
-        owning_nodes_name: "{{ owning_nodes_name }} + [ '{{ item.adminNodeName }}' ]"
+          owning_nodes_name: "{{ owning_nodes_name + [item.adminNodeName] }}"
       with_items: "{{ owning_cluster_nodes.json.nodes }}"
       run_once: True
-
+  
 #
 # This Section is when using daemonNodeName
 #
@@ -312,7 +312,7 @@
       run_once: True
 
     - set_fact:
-        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
+        owning_daemon_nodes_name: "{{ owning_daemon_nodes_name + [item.json.nodes.0.network.daemonNodeName] }}"
       with_items: "{{ owning_cluster_daemonnodes.results }}"
       run_once: True
 
@@ -427,19 +427,21 @@
   ignore_errors: true
   run_once: True
 
-
 - name: "Mount Filesystem | Storage Cluster (owner) | Check if filesystems is accessible on Client Cluster ('{{ access_cluster_name }}') - Debug"
   run_once: True
   debug:
-    msg: "{{ remote_clusters_results.json.remoteClusters[0] | json_query('owningClusterFilesystems[*].filesystem') | join(', ')  }}"
-  when: scale_remotemount_debug | bool
+    msg: "{{ remote_clusters_results.json.remoteClusters[0].owningClusterFilesystems| map(attribute='filesystem') | list | join(', ') }}"
+  when:
+   - scale_remotemount_debug | bool
+   - remote_clusters_results.json.remoteClusters[0].owningClusterFilesystems is defined
 
 # Set current filesystem access and run only the access task on filesystem, this is a list
 # this could also be changed to a import_task with loop.
 
 - set_fact:
-    current_scale_remotemount_storage_filesystem_name: "{{ remote_clusters_results.json.remoteClusters[0] | json_query('owningClusterFilesystems[*].filesystem') | join(', ')  }}"
+    current_scale_remotemount_storage_filesystem_name: "{{ remote_clusters_results.json.remoteClusters[0].owningClusterFilesystems| map(attribute='filesystem') | list | join(', ') }}"
   run_once: True
+  when: remote_clusters_results.json.remoteClusters[0].owningClusterFilesystems is defined
 
 - name: Step 6 - Configure and Mount filesystems
   debug:

--- a/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
+++ b/roles/remotemount_configure/tasks/remotecluster_api_cli.yml
@@ -10,6 +10,7 @@
 - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET the Cluster Information
   uri:
     validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+    ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/cluster
     method: GET
@@ -58,6 +59,7 @@
 - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | Check if the Client Cluster ('{{ access_cluster_name }}') is already defined"
   uri:
     validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+    ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
     force_basic_auth: yes
     url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
     method: GET
@@ -74,7 +76,7 @@
 - name: Remote Cluster Config - API-CLI | Client Cluster (access) | Check if the Storage Cluster ('{{ owning_cluster_name }}') is already defined on Client"
   run_once: True
   shell: |
-    /usr/lpp/mmfs/bin/mmremotecluster show {{ owning_cluster_name }}
+    /usr/lpp/mmfs/bin/mmremotecluster show {{ owning_cluster_name | quote }}
   register: remote_cluster_check_owning_cluster
   ignore_errors: true
   changed_when: false
@@ -84,6 +86,7 @@
     - name: "DELETE: {{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}"
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters/{{ access_cluster_name }}
         method: DELETE
@@ -97,6 +100,7 @@
     - name: "Checking results from the job: {{ delete_call.json.jobs[0].jobId }}"
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ delete_call.json.jobs[0].jobId }}
         method: GET
@@ -198,6 +202,7 @@
     - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Send the Public Key of the Client Cluster (access) to Storage Cluster (Owner)
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/remoteclusters
         method: POST
@@ -220,6 +225,7 @@
     - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | Check the result of adding the Client Cluster {{ send_key.json.jobs[0].jobId }}"
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: true
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/jobs/{{ send_key.json.jobs[0].jobId }}
         method: GET
@@ -236,6 +242,7 @@
     - name: Remote Cluster Config - API-CLI | Storage Cluster (owner) | Get the Public Key
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_endpoint }}/authenticationkey/
         method: GET
@@ -276,6 +283,7 @@
     - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET adminNodeName Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes"
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: yes
         url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes{{ scale_remotemount_storage_contactnodes_filter }}
         method: GET
@@ -287,22 +295,15 @@
       register: owning_cluster_nodes
       run_once: True
 
-    - set_fact:
-        owning_nodes_name: []
+    - name: Remote Cluster Config - API-CLI | Build owning_nodes_name
+      set_fact:
+        owning_nodes_name: >-
+          {{
+            owning_cluster_nodes.json.nodes
+            | map(attribute='adminNodeName')
+            | list
+          }}
       run_once: True
-
-    - set_fact:
-        owning_nodes_name: "{{ owning_cluster_nodes.json.nodes | map(attribute='adminNodeName') | list }}"
-      run_once: True
-
-    - name: Debug owning_nodes_name
-      debug:
-        var: owning_nodes_name
-
-    - name: Debug each item
-      debug:
-        var: item
-      loop: "{{ owning_nodes_name }}"
 
 #
 # This Section is when using daemonNodeName
@@ -310,8 +311,9 @@
     - name: "Remote Cluster Config - API-CLI | Storage Cluster (owner) | GET daemonNodeName Info - GET {{ scale_remotemount_scalemgmt_endpoint }}/nodes/"
       uri:
         validate_certs: "{{ scale_remotemount_validate_certs_uri }}"
+        ca_path: "{{ scale_remotemount_ca_bundle_path | default(omit) }}"
         force_basic_auth: yes
-        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{ item }}
+        url: https://{{ scale_remotemount_storage_gui_hostname }}:{{ scale_remotemount_storage_cluster_gui_port }}/{{ scale_remotemount_scalemgmt_endpoint }}/nodes/{{item}}
         method: GET
         user: "{{ scale_remotemount_storage_gui_username }}"
         password: "{{ scale_remotemount_storage_gui_password }}"
@@ -322,22 +324,17 @@
       with_items: "{{ owning_nodes_name }}"
       run_once: True
 
-    - set_fact:
-        owning_daemon_nodes_name: []
+    - name: Remote Cluster Config - API-CLI | Build owning_daemon_nodes_name
+      set_fact:
+        owning_daemon_nodes_name: >-
+          {{
+            owning_cluster_daemonnodes.results
+            | map(attribute='json.nodes.0.network.daemonNodeName')
+            | list
+          }}
       run_once: True
 
-        #- set_fact:
-        #owning_daemon_nodes_name: "{{ owning_daemon_nodes_name }} + [ '{{ item.json.nodes.0.network.daemonNodeName }}' ]"
-        #with_items: "{{ owning_cluster_daemonnodes.results }}"
-        #run_once: True
 
-    - set_fact:
-        owning_daemon_nodes_name: "{{ owning_cluster_daemonnodes.results | map(attribute='json.nodes.0.network.daemonNodeName') | list }}"
-      run_once: True
-
-    - name: Print out the array storing the DeamonNodeNames from the Storage Cluster (owning)
-      debug:
-        var: owning_daemon_nodes_name
 
 #
 # adminNodeName section
@@ -351,7 +348,7 @@
     - name: Remote Cluster Config - API-CLI | Client Cluster (Access) | Install storage cluster (owner) public key in remote cluster with adminNodeName
       run_once: True
       shell: |
-        /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name }} -n {{ owning_nodes_name | list | join(',') }} -k {{ scale_remotemount_storage_pub_key_location }}
+        /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name | quote }} -n {{ owning_nodes_name | map('quote') | join(',') }} -k {{ scale_remotemount_storage_pub_key_location | quote }}
       register: remote_cluster_add_ssh
       failed_when:
         - "remote_cluster_add_ssh.rc != 0 and 'is already defined' not in remote_cluster_add_ssh.stderr"
@@ -368,7 +365,7 @@
     - name: Remote Cluster Config - API-CLI | Client Cluster (Access) |  Install storage cluster (owner) public key in remote cluster with daemonNodeName
       run_once: True
       shell: |
-        /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name }} -n {{ owning_daemon_nodes_name | list | join(',') }} -k {{ scale_remotemount_storage_pub_key_location }}
+        /usr/lpp/mmfs/bin/mmremotecluster add {{ owning_cluster_name | quote }} -n {{ owning_daemon_nodes_name | map('quote') | join(',') }} -k {{ scale_remotemount_storage_pub_key_location | quote }}
       register: remote_cluster_add_ssh
       failed_when:
         - "remote_cluster_add_ssh.rc != 0 and 'is already defined' not in remote_cluster_add_ssh.stderr"

--- a/samples/playbook_compute_mrot.yml
+++ b/samples/playbook_compute_mrot.yml
@@ -85,8 +85,20 @@
 
   # Task to check and add custom routing tables on cluster nodes.
 
+  - name: Check for /etc/iproute2/rt_tables
+    stat:
+      path: /etc/iproute2/rt_tables
+    register: etc_rt_tables
+
+  - name: Set rt_tables path
+    set_fact:
+      rt_tables_path: >-
+        {{ '/etc/iproute2/rt_tables'
+          if etc_rt_tables.stat.exists
+          else '/usr/share/iproute2/rt_tables' }}  
+
   - name: check | Check if custom routing tables exist
-    shell: grep -q 'subnet_{{ compute_network_addr.stdout }}_{{ scale_pri_interface_name }}' /etc/iproute2/rt_tables && grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}' /etc/iproute2/rt_tables
+    shell: grep -q 'subnet_{{ compute_network_addr.stdout }}_{{ scale_pri_interface_name }}' {{ rt_tables_path }} && grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}' {{ rt_tables_path }}
     register: routing_table_exists
     ignore_errors: yes
     failed_when: routing_table_exists.rc == 2
@@ -96,8 +108,8 @@
 
   - name: configure | Custom routing tables
     shell: |
-      echo "200 subnet_{{ compute_network_addr.stdout }}_{{ scale_pri_interface_name }}" >> /etc/iproute2/rt_tables
-      echo "201 subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}" >> /etc/iproute2/rt_tables
+      echo "200 subnet_{{ compute_network_addr.stdout }}_{{ scale_pri_interface_name }}" >> {{ rt_tables_path }}
+      echo "201 subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}" >> {{ rt_tables_path }}
     when: routing_table_exists.rc != 0
 
   # Task to check and add custom IP rules on cluster nodes.

--- a/samples/playbook_storage_mrot.yml
+++ b/samples/playbook_storage_mrot.yml
@@ -85,8 +85,20 @@
 
   # Task to check and add custom routing tables on cluster nodes.
 
+  - name: Check for /etc/iproute2/rt_tables
+    stat:
+      path: /etc/iproute2/rt_tables
+    register: etc_rt_tables
+
+  - name: Set rt_tables path
+    set_fact:
+      rt_tables_path: >-
+        {{ '/etc/iproute2/rt_tables'
+          if etc_rt_tables.stat.exists
+          else '/usr/share/iproute2/rt_tables' }}
+
   - name: check | Check if custom routing tables exist
-    shell: grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_pri_interface_name }}' /etc/iproute2/rt_tables && grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}' /etc/iproute2/rt_tables
+    shell: grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_pri_interface_name }}' {{ rt_tables_path }} && grep -q 'subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}' {{ rt_tables_path }}
     register: routing_table_exists
     ignore_errors: yes
     failed_when: routing_table_exists.rc == 2
@@ -96,8 +108,8 @@
 
   - name: configure | Custom routing tables
     shell: |
-      echo "200 subnet_{{ storage_network_addr.stdout }}_{{ scale_pri_interface_name }}" >> /etc/iproute2/rt_tables
-      echo "201 subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}" >> /etc/iproute2/rt_tables
+      echo "200 subnet_{{ storage_network_addr.stdout }}_{{ scale_pri_interface_name }}" >> {{ rt_tables_path }}
+      echo "201 subnet_{{ storage_network_addr.stdout }}_{{ scale_sec_interface_name }}" >> {{ rt_tables_path }}
     when: routing_table_exists.rc != 0
 
   # Task to check and add custom IP rules on cluster nodes.


### PR DESCRIPTION
@rajan-mis 

- Updating the path to `iproute2` route tables to support for both RHEL-8 and RHEL-9.
- Kindly review and merge the changes.